### PR TITLE
cocotb support

### DIFF
--- a/package.json
+++ b/package.json
@@ -491,17 +491,22 @@
 				},
 				{
 					"command": "teroshdl_tree_view.run_vunit_test",
-					"when": "view == teroshdl_tree_view && viewItem == test",
+					"when": "view == teroshdl_tree_view && viewItem == test_vunit",
 					"group": "inline"
 				},
 				{
 					"command": "teroshdl_tree_view.run_vunit_test_gui",
-					"when": "view == teroshdl_tree_view && viewItem == test",
+					"when": "view == teroshdl_tree_view && viewItem == test_vunit",
 					"group": "inline"
 				},
 				{
 					"command": "teroshdl_tree_view.go_to_code",
-					"when": "view == teroshdl_tree_view && viewItem == test",
+					"when": "viewItem == test_cocotb || viewItem == test_vunit && view == teroshdl_tree_view",
+					"group": "inline"
+				},
+				{
+					"command": "teroshdl_tree_view.run_cocotb_test",
+					"when": "view == teroshdl_tree_view && viewItem == test_cocotb",
 					"group": "inline"
 				},
 				{
@@ -580,6 +585,14 @@
 			{
 				"command": "teroshdl_tree_view.run_vunit_test",
 				"title": "Run VUnit test",
+				"icon": {
+					"light": "resources/light/run.svg",
+					"dark": "resources/dark/run.svg"
+				}
+			},
+			{
+				"command": "teroshdl_tree_view.run_cocotb_test",
+				"title": "Run Cocotb test",
 				"icon": {
 					"light": "resources/light/run.svg",
 					"dark": "resources/dark/run.svg"

--- a/src/lib/project_manager/cocotb.ts
+++ b/src/lib/project_manager/cocotb.ts
@@ -166,7 +166,7 @@ export class Cocotb {
     return results;
   }
 
-  async get_test_list(python3_path, runpy_path) {
+  async get_test_list() : Promise<TestItem[]> {
     let wksp_folder;
     if(vscode.workspace.workspaceFolders !== undefined) {
       wksp_folder = vscode.workspace.workspaceFolders[0].uri.fsPath;

--- a/src/lib/project_manager/cocotb.ts
+++ b/src/lib/project_manager/cocotb.ts
@@ -215,8 +215,14 @@ export class Cocotb {
         const module_path = path_lib.dirname(makefile.makefile);
         const filename = path_lib.join(module_path, test_name);
 
-        let python_cocotb_data = fs.readFileSync(`${filename}.py`);
-
+        let python_cocotb_data;
+        try {
+          python_cocotb_data = fs.readFileSync(`${filename}.py`);
+        } catch {
+          vscode.window.showErrorMessage(`Found "${module}" module in Makefile's MODULE variable but no "${test_name}.py" file found`);
+          continue;
+        }
+        
         let input = python_cocotb_data.toString();
         let regex = /(^[^#\r\n]* *@cocotb\.test\(\)(\r\n|\n|\r))([^#\r\n]* *(async )?def ([\w_]+)\([\w_]+\):$)/gm;
         

--- a/src/lib/project_manager/cocotb.ts
+++ b/src/lib/project_manager/cocotb.ts
@@ -46,23 +46,6 @@ export class Cocotb {
     }
   }
 
-  async get_python3_path(python3_path) {
-    let python_path = '';
-    if (python3_path === '') {
-      python_path = await colibri.Nopy.get_python_exec();
-    }
-    else {
-      python_path = python3_path;
-    }
-
-    if (python_path === undefined || python_path === '') {
-      this.output_channel.append('[Error] Install and configure Python3 in the extension configuration.');
-      this.output_channel.show();
-      return undefined;
-    }
-    return python_path;
-  }
-
   async run_simulation(tests_names: string[] = [], cocotb_test_list: TestItem[] = []) {
     let makefiles_to_run = new Map<string, string[]>();
 
@@ -103,53 +86,6 @@ export class Cocotb {
     }
 
     return results;
-  }
-
-  async get_command(python3_path, runpy_dirname, runpy_filename, simulator,
-    simulator_install_path, extra_options, gui, list = false, tests: string[] = []) {
-
-    let python3_path_exec = await this.get_python3_path(python3_path);
-    if (python3_path_exec === undefined) {
-      return undefined;
-    }
-
-    let tests_cmd = ' ';
-    for (let i = 0; i < tests.length; i++) {
-      if (i === 0) {
-        tests_cmd += '"';
-      }
-      const element = tests[i];
-      if (i === tests.length - 1) {
-        tests_cmd += `${element}"`;
-      }
-    }
-
-    let list_cmd = '';
-    if (list === true) {
-      list_cmd = '--export-json teroshdl_export.json';
-    }
-
-    let gui_cmd = '';
-    if (gui === true) {
-      extra_options = '';
-      gui_cmd = '--gui';
-    }
-
-    let simulator_config = this.get_simulator_config(simulator, simulator_install_path);
-    let go_to_dir = `cd ${runpy_dirname}${this.more}`;
-    let vunit_default_options = `--no-color -x teroshdl_out.xml --exit-0 ${gui_cmd} ${list_cmd}`;
-    let command = `${simulator_config}${go_to_dir}${python3_path_exec} ${runpy_filename} ${tests_cmd} ${vunit_default_options}${extra_options}`;
-
-    return command;
-  }
-
-  get_simulator_config(simulator_name, simulator_install_path) {
-    let simulator_name_up = simulator_name.toUpperCase();
-    let simulator_name_low = simulator_name.toLowerCase();
-
-    let simulator_cmd = `${this.exp} VUNIT_${simulator_name_up}_PATH=${simulator_install_path}${this.more}${this.exp} VUNIT_SIMULATOR=${simulator_name_low}${this.more}`;
-
-    return simulator_cmd;
   }
 
   async run_makefile(dir, filename, tests) {

--- a/src/lib/project_manager/cocotb.ts
+++ b/src/lib/project_manager/cocotb.ts
@@ -1,0 +1,347 @@
+import * as vscode from 'vscode';
+import { resourceLimits } from 'worker_threads';
+
+const path_lib = require('path');
+const os = require('os');
+const shell = require('shelljs');
+const fs = require('fs');
+const colibri = require('jsteros');
+const glob = require( 'glob' );
+const tmp = require('tmp');
+const child_process = require("child_process");
+
+export interface TestItem {
+  attributes: string | undefined;
+  location: {
+    file_name: string;
+    length: number;
+    offset: number;
+    parent_makefile: string;
+  } | undefined;
+  name: string;
+}
+
+export class Cocotb {
+  private output_channel;
+  private exp: string = '';
+  private more: string = '';
+  private folder_sep: string = '';
+  private childp;
+  private context;
+
+  constructor(context) {
+    this.context = context;
+    this.output_channel = vscode.window.createOutputChannel('TerosHDL');
+
+    this.exp = "export ";
+    this.more = ";";
+    this.folder_sep = "/";
+
+    if (os.platform() === "win32") {
+      this.exp = "SET ";
+      this.more = "&&";
+      this.folder_sep = "\\";
+    }
+  }
+
+  async get_python3_path(python3_path) {
+    let python_path = '';
+    if (python3_path === '') {
+      python_path = await colibri.Nopy.get_python_exec();
+    }
+    else {
+      python_path = python3_path;
+    }
+
+    if (python_path === undefined || python_path === '') {
+      this.output_channel.append('[Error] Install and configure Python3 in the extension configuration.');
+      this.output_channel.show();
+      return undefined;
+    }
+    return python_path;
+  }
+
+  async run_simulation(tests_names: string[] = [], cocotb_test_list: TestItem[] = []) {
+    // this.output_channel.clear();
+    // let options_vunit = selected_tool_configuration['vunit'];
+    // if (options_vunit === undefined) {
+    //   let results = this.get_all_test_fail(tests);
+    //   this.output_channel.append('[Error] Select VUnit as you tool.');
+    //   this.output_channel.show();
+    //   return results;
+    // }
+
+    // let simulator = options_vunit.simulator;
+    // let simulator_install_path = '';
+    // let extra_options = ` ${options_vunit.options} `;
+    // for (let i = 0; i < all_tool_configuration.length; i++) {
+    //   const tool = all_tool_configuration[i];
+    //   let tool_name = '';
+    //   for (var attributename in tool) {
+    //     tool_name = attributename;
+    //   }
+
+    //   if (tool_name === simulator) {
+    //     simulator_install_path = tool[tool_name].installation_path;
+    //     break;
+    //   }
+    // }
+
+    // let runpy_dirname = path_lib.dirname(runpy_path);
+    // let runpy_filename = path_lib.basename(runpy_path);
+    // let command = await this.get_command(python3_path, runpy_dirname,
+    //   runpy_filename, simulator, simulator_install_path, extra_options, gui, false, tests);
+
+    // if (command === undefined) {
+    //   return [];
+    // }
+
+    // let result = await this.run_command(command, runpy_dirname, tests);
+    // return result;
+
+
+    for (let cocotb_test_item of cocotb_test_list)
+    {
+      let index_of_test = tests_names.indexOf(cocotb_test_item.name);
+      if (index_of_test > -1)
+      {
+        let test_name = tests_names[index_of_test];
+        console.log(test_name);
+        console.log(cocotb_test_item.location?.parent_makefile);
+        let command = `make -f ${cocotb_test_item.location?.parent_makefile}`;
+        let result = await this.run_command(command, tests_names);
+        return result;
+      }
+    }
+    return [];
+  }
+
+  async get_command(python3_path, runpy_dirname, runpy_filename, simulator,
+    simulator_install_path, extra_options, gui, list = false, tests: string[] = []) {
+
+    let python3_path_exec = await this.get_python3_path(python3_path);
+    if (python3_path_exec === undefined) {
+      return undefined;
+    }
+
+    let tests_cmd = ' ';
+    for (let i = 0; i < tests.length; i++) {
+      if (i === 0) {
+        tests_cmd += '"';
+      }
+      const element = tests[i];
+      if (i === tests.length - 1) {
+        tests_cmd += `${element}"`;
+      }
+    }
+
+    let list_cmd = '';
+    if (list === true) {
+      list_cmd = '--export-json teroshdl_export.json';
+    }
+
+    let gui_cmd = '';
+    if (gui === true) {
+      extra_options = '';
+      gui_cmd = '--gui';
+    }
+
+    let simulator_config = this.get_simulator_config(simulator, simulator_install_path);
+    let go_to_dir = `cd ${runpy_dirname}${this.more}`;
+    let vunit_default_options = `--no-color -x teroshdl_out.xml --exit-0 ${gui_cmd} ${list_cmd}`;
+    let command = `${simulator_config}${go_to_dir}${python3_path_exec} ${runpy_filename} ${tests_cmd} ${vunit_default_options}${extra_options}`;
+
+    return command;
+  }
+
+  get_simulator_config(simulator_name, simulator_install_path) {
+    let simulator_name_up = simulator_name.toUpperCase();
+    let simulator_name_low = simulator_name.toLowerCase();
+
+    let simulator_cmd = `${this.exp} VUNIT_${simulator_name_up}_PATH=${simulator_install_path}${this.more}${this.exp} VUNIT_SIMULATOR=${simulator_name_low}${this.more}`;
+
+    return simulator_cmd;
+  }
+
+  async run_command(command, tests) {
+    let element = this;
+
+    element.output_channel.append(command);
+    element.output_channel.show();
+
+    return new Promise(resolve => {
+      this.childp = shell.exec(command, { async: true }, async function (code, stdout, stderr) {
+        if (code === 0) {
+          // let results = await element.get_result("", tests);
+          resolve([]);
+        }
+        else {
+          let results = element.get_all_test_fail(tests);
+          resolve(results);
+        }
+      });
+
+      this.childp.stdout.on('data', function (data) {
+        element.output_channel.append(data);
+        element.output_channel.show();
+      });
+      this.childp.stderr.on('data', function (data) {
+        element.output_channel.append(data);
+        element.output_channel.show();
+      });
+    });
+  }
+
+  async get_result(folder, tests) {
+    // const result_file = `${folder}${this.folder_sep}teroshdl_out.xml`;
+    // const xml2js = require('xml2js');
+    // const parser = new xml2js.Parser({ attrkey: "atrr" });
+
+    // // this example reads the file synchronously
+    // // you can read it asynchronously also
+    // let xml_string = fs.readFileSync(result_file, "utf8");
+
+    // return new Promise(resolve => {
+    //   try {
+    //     parser.parseString(xml_string, function (error, result) {
+    //       let testsuites = result.testsuite;
+    //       let testcase = testsuites.testcase;
+    //       let results: {}[] = [];
+    //       for (let i = 0; i < testcase.length; i++) {
+    //         const test = testcase[i];
+    //         let test_name = `${test.atrr.classname}.${test.atrr.name}`;
+    //         let pass = true;
+    //         if (test.failure !== undefined) {
+    //           pass = false;
+    //         }
+    //         let test_info = {
+    //           name: test_name,
+    //           pass: pass
+    //         };
+    //         results.push(test_info);
+    //       }
+    //       resolve(results);
+    //     });
+    //   } catch (e) {
+    //     let results = this.get_all_test_fail(tests);
+    //     resolve(results);
+    //   }
+
+    return new Promise(resolve => {
+      let results: {}[] = [];
+
+      let result = {testsuite: {testcase: {atrr: {classname: '', name: ''}, failure: false}}};
+
+      let testsuites = result.testsuite;
+      let testcase = [testsuites.testcase];
+      const test = testcase[0];
+
+      let test_name = `${test.atrr.classname}.${test.atrr.name}`;
+      let pass = true;
+  
+      if (test.failure !== undefined) {
+        pass = false;
+      }
+  
+      let test_info = {
+        name: test_name,
+        pass: pass
+      };
+  
+      results.push(test_info);
+  
+      resolve(results);
+    });
+  };
+
+  get_all_test_fail(tests) {
+    let results: {}[] = [];
+    for (let i = 0; i < tests.length; i++) {
+      const test_name = tests[i];
+      let test_info = {
+        name: test_name,
+        pass: false
+      };
+      results.push(test_info);
+    }
+    return results;
+  }
+
+  async get_test_list(python3_path, runpy_path) {
+    let wksp_folder;
+    if(vscode.workspace.workspaceFolders !== undefined) {
+      wksp_folder = vscode.workspace.workspaceFolders[0].uri.fsPath;
+    } else {
+      return([]);
+    }
+
+    let found_makefiles = glob.sync('/**/Makefile', {root: wksp_folder});
+    let cocotb_makefiles: {makefile: string, modules: [string]}[] = [];
+
+    const cocotb_makefile_must_contain = "include $(shell cocotb-config --makefiles)/Makefile.sim";
+
+    for (let item of found_makefiles) {
+      let data = fs.readFileSync(path_lib.resolve(item));
+      if (data.includes(cocotb_makefile_must_contain)) {
+        var new_data = data.toString().replace(cocotb_makefile_must_contain, '');
+        const tmpobj = tmp.fileSync();
+
+        fs.writeFileSync(tmpobj.name, `${new_data}\nprint-%  : ; @echo $* = $($*)\n`);
+
+        let modules = child_process.execSync(`make -f ${tmpobj.name} print-MODULE`).toString();
+        modules = modules.replace(/(\r\n|\n|\r)/, '');
+        let modules_arr = modules.split(' ');
+        modules_arr = modules_arr.filter(item => item !== "MODULE");
+        modules_arr = modules_arr.filter(item => item !== "=");
+        cocotb_makefiles.push({makefile: item, modules: modules_arr});
+      }
+    }
+
+    let test_array: TestItem[] = [];
+
+    for (let makefile of cocotb_makefiles) {
+      for (let module of makefile.modules) {
+        const test_name = module;
+        const module_path = path_lib.dirname(makefile.makefile);
+        const filename = path_lib.join(module_path, test_name);
+
+        const test_item: TestItem = {
+          attributes: "",
+          location: {
+            file_name: `${filename}.py`,
+            length: 1,
+            offset: 1,
+            parent_makefile: path_lib.resolve(makefile.makefile)
+          },
+          name: test_name
+        };
+
+        test_array.push(test_item);
+     }
+    }
+
+    return(test_array);
+  }
+
+  async stop_test() {
+    let path_bin = `${path_lib.sep}resources${path_lib.sep}bin${path_lib.sep}kill_vunit${path_lib.sep}kill.sh`;
+
+    if (this.childp === undefined) {
+      return;
+    }
+    try {
+      var os = require('os');
+      if (os.platform === "win32") {
+        var cmd = "TASKKILL /F /T /PID  " + (this.childp.pid);
+      }
+      else {
+        var path_kill = this.context.asAbsolutePath(path_bin);
+        var cmd = "bash " + path_kill + " " + (this.childp.pid);
+      }
+      shell.exec(cmd, { async: true }, function (error, stdout, stderr) {
+      });
+    }
+    catch (e) { }
+  }
+
+}

--- a/src/lib/project_manager/cocotb.ts
+++ b/src/lib/project_manager/cocotb.ts
@@ -89,6 +89,12 @@ export class Cocotb {
   }
 
   async run_makefile(dir, filename, tests) {
+    if (shell.exec("cocotb-config -v").code == 127)
+    {
+      vscode.window.showErrorMessage("Install cocotb itself to run tests");
+      return([]);
+    }
+
     let element = this;
 
     element.output_channel.append(`Run makefile '${filename}' from directory '${dir}'\r\n`);
@@ -167,6 +173,12 @@ export class Cocotb {
   }
 
   async get_test_list() : Promise<TestItem[]> {
+    if (shell.exec("make").code == 127)
+    {
+      vscode.window.showErrorMessage("Install Make to use cocotb");
+      return([]);
+    }
+
     let wksp_folder;
     if(vscode.workspace.workspaceFolders !== undefined) {
       wksp_folder = vscode.workspace.workspaceFolders[0].uri.fsPath;

--- a/src/lib/project_manager/cocotb.ts
+++ b/src/lib/project_manager/cocotb.ts
@@ -101,7 +101,6 @@ export class Cocotb {
     element.output_channel.show();
 
     return new Promise(resolve => {
-      //@chcp 65001 >nul & cmd /d/s/c 
       shell.cd(dir);
       this.childp = shell.exec(`make -f ${filename}`, { async: true, encoding: "UTF-8" }, async function (code, stdout, stderr) {
         if (code === 0) {

--- a/src/lib/project_manager/project_manager.ts
+++ b/src/lib/project_manager/project_manager.ts
@@ -738,42 +738,6 @@ class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
     this.update_tree();
   }
 
-  set_cocotb_results(results, force_fail_all) {
-    if (results === undefined) {
-      return;
-    }
-    if (force_fail_all === true) {
-      this.set_fail_all_tests();
-      return;
-    }
-    for (let i = 0; i < this.cocotb_test_list_items.length; ++i) {
-      const test = this.cocotb_test_list_items[i];
-      for (let j = 0; j < results.length; j++) {
-        const result = results[j];
-        if (test.label === result.name) {
-
-          if (result.pass === false) {
-            let path_icon_light = path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'failed.svg');
-            let path_icon_dark = path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'failed.svg');
-            test.iconPath = {
-              light: path_icon_light,
-              dark: path_icon_dark
-            };
-          }
-          else {
-            let path_icon_light = path.join(__filename, '..', '..', '..', '..', 'resources', 'light', 'passed.svg');
-            let path_icon_dark = path.join(__filename, '..', '..', '..', '..', 'resources', 'dark', 'passed.svg');
-            test.iconPath = {
-              light: path_icon_light,
-              dark: path_icon_dark
-            };
-          }
-        }
-      }
-    }
-    this.update_tree();
-  }
-
   set_fail_all_tests() {
     for (let i = 0; i < this.vunit_test_list_items.length; ++i) {
       const test = this.vunit_test_list_items[i];

--- a/src/lib/project_manager/project_manager.ts
+++ b/src/lib/project_manager/project_manager.ts
@@ -449,6 +449,7 @@ export class Project_manager {
 
     this.set_default_tops();
     this.set_vunit_results(false);
+    this.set_cocotb_results(false);
 
     let vunit_test_list_result = await this.get_vunit_test_list();
     let cocotb_test_list_result = await this.get_cocotb_test_list();
@@ -460,6 +461,7 @@ export class Project_manager {
     }
     this.set_default_tops();
     this.set_vunit_results(false);
+    this.set_cocotb_results(false);
   }
 
   set_default_tops() {

--- a/src/lib/project_manager/project_manager.ts
+++ b/src/lib/project_manager/project_manager.ts
@@ -282,7 +282,7 @@ export class Project_manager {
     if (results.length === 0) {
       force_fail_all = true;
     }
-    this.set_vunit_results(force_fail_all);
+    this.set_results(force_fail_all, 'vunit');
   }
 
   async run_cocotb_tests(tests) {   
@@ -293,7 +293,7 @@ export class Project_manager {
     if (results.length === 0) {
       force_fail_all = true;
     }
-    this.set_cocotb_results(force_fail_all);
+    this.set_results(force_fail_all, 'cocotb');
   }
 
   getline_numberof_char(path, index) {
@@ -353,12 +353,11 @@ export class Project_manager {
     });
   }
 
-  set_vunit_results(force_fail_all) {
-    this.tree.set_results(this.last_vunit_results, this.tree.vunit_test_list_items, force_fail_all);
-  }
+  set_results(force_fail_all, context: string) {
+    let last_results_parameter_name = `last_${context}_results`;
+    let new_results_parameter_name = `${context}_test_list_items`;
 
-  set_cocotb_results(force_fail_all) {
-    this.tree.set_results(this.last_cocotb_results, this.tree.cocotb_test_list_items, force_fail_all);
+    this.tree.set_results(this[last_results_parameter_name], this.tree[new_results_parameter_name], force_fail_all);
   }
 
   set_top_from_project(project_name, library_name, path) {
@@ -425,8 +424,8 @@ export class Project_manager {
     }
 
     this.set_default_tops();
-    this.set_vunit_results(false);
-    this.set_cocotb_results(false);
+    this.set_results(false, 'vunit');
+    this.set_results(false, 'cocotb');
 
     let vunit_test_list_result = await this.get_vunit_test_list();
     let cocotb_test_list_result = await this.get_cocotb_test_list();
@@ -437,8 +436,8 @@ export class Project_manager {
       this.tree.select_project(selected_project);
     }
     this.set_default_tops();
-    this.set_vunit_results(false);
-    this.set_cocotb_results(false);
+    this.set_results(false, 'vunit');
+    this.set_results(false, 'cocotb');
   }
 
   set_default_tops() {

--- a/src/lib/project_manager/project_manager.ts
+++ b/src/lib/project_manager/project_manager.ts
@@ -225,8 +225,7 @@ export class Project_manager {
 
   async run_cocotb_test(item) {
     let tests: string[] = [item.label];
-    let gui = false;
-    this.run_cocotb_tests(tests, gui);
+    this.run_cocotb_tests(tests);
   }
 
   async run_vunit_test_gui(item) {
@@ -283,33 +282,7 @@ export class Project_manager {
     this.set_vunit_results(force_fail_all);
   }
 
-  async run_cocotb_tests(tests, gui) {
-    // let selected_tool_configuration = this.config_file.get_config_of_selected_tool();
-    // let all_tool_configuration = this.config_file.get_config_tool();
-
-    // let python3_path = <string>vscode.workspace.getConfiguration('teroshdl.global').get("python3-path");
-    // let selected_project = this.edam_project_manager.selected_project;
-    // let prj = this.edam_project_manager.get_project(selected_project);
-
-    // let runpy_path = '';
-    // if (prj.relative_path !== '' && prj.relative_path !== undefined) {
-    //   runpy_path = `${prj.relative_path}${path_lib.sep}${prj.toplevel_path}`;
-    // }
-    // else {
-    //   runpy_path = prj.toplevel_path;
-    // }
-
-    // let results = <[]>await this.cocotb.run_simulation(python3_path, selected_tool_configuration, all_tool_configuration,
-    //   runpy_path, tests, gui);
-      
-    // this.last_cocotb_results = results;
-    // let force_fail_all = false;
-    // if (results.length === 0) {
-    //   force_fail_all = true;
-    // }
-    // this.set_results(force_fail_all);
-
-    
+  async run_cocotb_tests(tests) {   
     let results = <[]>await this.cocotb.run_simulation(tests, this.cocotb_test_list);
 
     this.last_cocotb_results = results;

--- a/src/lib/project_manager/project_manager.ts
+++ b/src/lib/project_manager/project_manager.ts
@@ -252,8 +252,11 @@ export class Project_manager {
       tool_options: tool_configuration
     };
 
-    this.run_vunit_tests([], false);
-    this.run_cocotb_tests([], false);
+    if (tool_configuration !== undefined)
+    {
+      this.run_vunit_tests([], false);
+    }
+    this.run_cocotb_tests([]);
   }
 
   async run_vunit_tests(tests, gui) {
@@ -380,6 +383,7 @@ export class Project_manager {
 
   stop() {
     this.vunit.stop_test();
+    this.cocotb.stop_test();
   }
 
   private show_export_message(msg) {


### PR DESCRIPTION
Tested on Ubuntu WSL.

![image](https://user-images.githubusercontent.com/1484766/111015323-32d5e880-83b9-11eb-8e04-83039135b8e5.png)

The integration to the project manager was done by duplicating code because I don't understand how to do it right.

To check how it works, the second test tree window was added.
Original VS Code's ViewItem 'tests' were renamed to 'test_vuint' and 'test_cocotb' was added to split action buttons.

The key change is the 'cocotb.ts' file. It is similar to the 'vunit.ts':

### get_test_list()
The function finds files in the workspace folder with the "Makefile" name.
The function finds "_include $(shell cocotb-config --makefiles)/Makefile.sim_" string in Makefiles in the workspace. This string denotes that the Makefile is cocotb related.
Next, the function gets names of modules that are declared in the found Makefiles in the "MODULE" variable.
To make it done:

- The function copies the file to a temp folder and cuts the part where the string includes internal cocotb makefiles. Cutting is necessary to get no errors if for example _cocotb-config_ is not installed.
- Next, the function adds to the Makefile file a new Make target that prints the "MODULE" variable. It is necessary to handle Makefile syntax correctly if, for example, the variable is multiline.
- By calling the added Make target, the caller gets the single line one space-separated string. So, a dedicated Makefile parser is not used and no package dependencies are increased.

Found module names are the list of test suites. Every test suite item name matches with a Python file name where cocotb test case is located. Regex string is used to get a Python method name which is the test case name.
After all, the function adds test suites and test cases to the VsCode test tree.
 
### run_simulation()
The function gathers Makefiles from the passed tests list. Note, that cocotb can contain several test cases in one test suite. In cocotb it is implemented as a Python file with several decorated methods.
So the function gathers the unique list of Makefile and passes them to run_makefile()

### run_makefile()
Passes Makefile to run by Make
 
### get_result()
cocotb complets simulation with 'results.xml' file.
The file goes parse. The function adds a pass or a fail result to the VS Code test list.

### get_all_test_fail()
Is a copy of the original VUnit.

### stop_test()
Is a copy of the original VUnit.
