### PR TITLE
Fix function to get python executable

### DIFF
--- a/src/lib/formatter/formatter_manager.ts
+++ b/src/lib/formatter/formatter_manager.ts
@@ -90,7 +90,7 @@ async function get_python_path() {
     let python = vscode.workspace.getConfiguration('teroshdl.global').get("python3-path");
     if (python === "") {
         const jsteros = require('jsteros');
-        python = await jsteros.Nopy.exec_python_script();
+        python = await jsteros.Nopy.get_python_exec();
     }
     return python;
 }


### PR DESCRIPTION
Change `exec_python_script` which yielded error by `get_python_exec` which return the python executable name