### PR TITLE
multi project manager cleanup

### DIFF
--- a/packages/colibri/src/project_manager/multi_project_manager.ts
+++ b/packages/colibri/src/project_manager/multi_project_manager.ts
@@ -17,302 +17,216 @@
 // You should have received a copy of the GNU General Public License
 // along with TerosHDL.  If not, see <https://www.gnu.org/licenses/>.
 
-import { t_file, t_action_result, t_watcher, } from "./common";
+import { t_file, t_action_result } from "./common";
 import { Config_manager } from "../config/config_manager";
-import { e_clean_step } from "./tool/common";
 import { Project_manager } from "./project_manager";
-import { t_test_declaration, t_test_result } from "./tool/common";
 import { e_config } from "../config/config_declaration";
 import * as file_utils from "../utils/file_utils";
-import { get_linter_name, get_linter_options } from "../config/utils";
 import { get_language_from_filepath } from "../utils/file_utils";
-import { LINTER_MODE, l_error } from "../linter/common";
-import { Linter } from "../linter/linter";
 
 import * as yaml from "js-yaml";
 import * as events from "events";
 import { get_project_info_from_quartus } from "./tool/quartus/utils";
 
+class ProjectNotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ProjectNotFoundError";
+    }
+}
+
+class ProjectOperationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ProjectOperationError";
+    }
+}
+
 export class Multi_project_manager {
     private project_manager_list: Project_manager[] = [];
-    private selected_project = "";
+    private selected_project_name = "";
     private global_config: Config_manager;
-    private name = "";
     private sync_file_path = "";
     private emitter: events.EventEmitter | undefined = undefined;
 
-    // Linter
-    private linter = new Linter();
-
-
-    constructor(name: string, global_config_sync_path: string, sync_file_path = "",
+    constructor(global_config_sync_path: string, sync_file_path = "",
         emitter: events.EventEmitter | undefined) {
 
-        this.name = name;
-        this.emitter = emitter;
         this.global_config = new Config_manager(global_config_sync_path);
         this.sync_file_path = sync_file_path;
-        this.load_from_sync_file();
+        this.emitter = emitter;
     }
 
-    get_name(): string {
-        return this.name;
-    }
+    ////////////////////////////////////////////////////////////////////////////
+    // Getters
+    ////////////////////////////////////////////////////////////////////////////
 
-    get_projects(): Project_manager[] {
+    public get_projects(): Project_manager[] {
         return this.project_manager_list;
     }
 
+    public get_selected_project(): Project_manager {
+        return this.get_project_by_name(this.selected_project_name);
+    }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Linter
-    ////////////////////////////////////////////////////////////////////////////
-    public async lint_from_file(file_path: string, mode: LINTER_MODE,
-        general_config: e_config): Promise<l_error[]> {
-
-        const file_lang = get_language_from_filepath(file_path);
-        const linter_name = get_linter_name(file_lang, mode, general_config);
-        const linter_options = get_linter_options();
-
-        const result = this.get_select_project();
-        if (result.successful === false) {
-            return await this.linter.lint_from_file(linter_name, file_path, linter_options);
+    public get_project_by_name(name: string): Project_manager {
+        let return_value: Project_manager | undefined = undefined;
+        this.project_manager_list.forEach(project => {
+            if (project.get_name() === name) {
+                return_value = project;
+            }
+        });
+        if (return_value === undefined) {
+            throw new ProjectNotFoundError(`Project ${name} could not be found.`);
         }
-        const prj_file_list = (<Project_manager>result.result).get_project_definition().file_manager.get();
-        return await this.linter.lint_from_project(file_path, prj_file_list, linter_name, linter_options);
+        return return_value;
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // Utils
+    // Load / Save in a file
     ////////////////////////////////////////////////////////////////////////////
-    public save() {
-        if (this.sync_file_path === "") {
-            return;
+    public load(): void {
+        try {
+            const file_content = file_utils.read_file_sync(this.sync_file_path);
+            const prj_saved = JSON.parse(file_content);
+
+            this.selected_project_name = prj_saved.selected_project;
+
+            const prj_list = prj_saved.project_list;
+            prj_list.forEach((prj_info: any) => {
+                const prj = this.initialize_project(prj_info.name);
+                // Files
+                prj_info.files.forEach((file: any) => {
+                    prj.add_file({
+                        name: file.name, is_include_file: file.is_include_file,
+                        include_path: file.include_path, logical_name: file.logical_name,
+                        is_manual: file.is_manual, file_type: file.file_type,
+                        file_version: file_utils.check_default_version_for_filepath(file.name, file.file_version)
+                    });
+                });
+                // Hooks
+                // Toplevel
+                prj.add_toplevel_path(prj_info.toplevel);
+                // Tool options
+                // Watchers
+                const watcher_list = prj_info.watchers;
+                watcher_list.forEach((watcher: any) => {
+                    prj.add_file_to_watcher(watcher);
+                });
+            });
         }
+        // eslint-disable-next-line no-empty
+        catch (error) {
+            // TODO Log the error
+        }
+    }
+
+    public save(): void {
         const prj_list: any[] = [];
         this.project_manager_list.forEach(prj => {
             prj_list.push(prj.get_edam_json());
         });
         const total = {
-            name: this.name,
-            selected_project: this.selected_project,
+            selected_project: this.selected_project_name,
             project_list: prj_list
         };
         const config_string = JSON.stringify(total, null, 4);
         file_utils.save_file_sync(this.sync_file_path, config_string);
     }
 
-    public load_from_sync_file() {
-        try {
-            const file_content = file_utils.read_file_sync(this.sync_file_path);
-            const prj_saved = JSON.parse(file_content);
-            this.name = prj_saved.name;
-            this.selected_project = prj_saved.selected_project;
-            const prj_list = prj_saved.project_list;
-            prj_list.forEach((prj: any) => {
-                const prj_name = prj.name;
-                this.create_project(prj_name);
-                // Files
-                const file_list = prj.files;
-                file_list.forEach((file: any) => {
-                    this.add_file(prj_name, {
-                        name: file.name, is_include_file: file.is_include_file,
-                        include_path: file.include_path, logical_name: file.logical_name,
-                        is_manual: file.is_manual, file_type: file.file_type, 
-                        file_version: file_utils.check_default_version_for_filepath(file.name, file.file_version)
-                    });
-                });
-                // Hooks
-                // Toplevel
-                this.add_toplevel_path(prj_name, prj.toplevel);
-                // Tool options
-                // Watchers
-                const watcher_list = prj.watchers;
-                watcher_list.forEach((watcher: any) => {
-                    this.add_file_to_watcher(prj_name, watcher);
-                });
-            });
-        }
-        // eslint-disable-next-line no-empty
-        catch (error) { }
-    }
-
     ////////////////////////////////////////////////////////////////////////////
-    // Project
+    // Project Actions
     ////////////////////////////////////////////////////////////////////////////
-    async create_project_from_quartus(general_config: e_config, prj_path: string): Promise<t_action_result> {
-        const result = await get_project_info_from_quartus(general_config, prj_path);
-        const result_prj_create = this.create_project(result.prj_name);
-        if (result_prj_create.successful === false) {
-            return result_prj_create;
-        }
-        let q_result = await this.add_file_from_quartus(result.prj_name, general_config, prj_path, true);
-        if (q_result.successful === false) {
-            return q_result;
-        }
-        q_result = await this.add_toplevel_path_from_entity(result.prj_name, result.prj_top_entity);
-        this.save();
-        return q_result;
-    }
-
-    public rename_project(prj_name: string, new_name: string) {
-        // Check if project to reanme exists
-        const exist_prj_0 = this.get_project_by_name(prj_name);
-        if (exist_prj_0 === undefined) {
-            return this.get_project_not_exist();
-        }
-        // Check if new name projec exists
-        const exist_prj_1 = this.get_project_by_name(new_name);
-        if (exist_prj_1 !== undefined) {
-            return this.get_project_exist();
-        }
-
-        exist_prj_0.rename(new_name);
-        this.save();
-        return this.get_sucessful_result(undefined);
-    }
-
-    public create_project(prj_name: string) {
-        const exist_prj = this.get_project_by_name(prj_name);
-        if (exist_prj !== undefined) {
-            return this.get_project_exist();
-        }
-        const prj = new Project_manager(prj_name, this.emitter);
-        this.project_manager_list.push(prj);
-        this.save();
-        return this.get_sucessful_result(undefined);
-    }
-
-    public create_project_from_json_edam(filepath: string) {
+    public initialize_project(prj_name: string): Project_manager {
         try {
-            const prj_info = JSON.parse(file_utils.read_file_sync(filepath));
-            return this.create_project_from_dict(prj_info, filepath);
-        } catch (error) {
-            return this.get_error_reading_prj();
-        }
-    }
-
-    public create_project_from_yaml_edam(filepath: string) {
-        try {
-            const prj_info = yaml.load(file_utils.read_file_sync(filepath));
-            return this.create_project_from_dict(prj_info, filepath);
-        } catch (error) {
-            return this.get_error_reading_prj();
-        }
-    }
-
-    public create_project_from_dict(prj_info: any, base_path: string) {
-        try {
-            // Create project
-            const prj_name = prj_info.name;
+            this.get_project_by_name(prj_name);
+            throw new ProjectOperationError(`Project ${prj_name} already exists. Please use a different name.`);
+        } catch (error) { // Not exists
             const prj = new Project_manager(prj_name, this.emitter);
-
-            // Check if exists
-            const exist_prj = this.get_project_by_name(prj_name);
-            if (exist_prj !== undefined) {
-                return this.get_project_exist();
-            }
-
-            // Add files
-            const file_list = prj_info.files;
-            file_list.forEach((file: any) => {
-                //Relative path to absolute
-                const name = file_utils.get_absolute_path(file_utils.get_directory(base_path), file.name);
-
-                let is_include_file = false;
-                if (file.is_include_file !== undefined) {
-                    is_include_file = file.is_include_file;
-                }
-                let include_path = "";
-                if (file.include_path !== undefined) {
-                    include_path = file.include_path;
-                }
-                let logical_name = "";
-                if (file.logical_name !== undefined) {
-                    logical_name = file.logical_name;
-                }
-                let is_manual = true;
-                if (file.is_manual !== undefined) {
-                    is_manual = file.is_manual;
-                }
-                let file_type = file.file_type;
-                if (file_type === undefined) {
-                    file_type = get_language_from_filepath(name);
-                }
-                let file_version = file_utils.check_default_version_for_filepath(name, file.file_version);
-                if (file_version === undefined) {
-                    file_version = file_utils.get_default_version_for_filepath(name);
-                }
-
-                const file_definition: t_file = {
-                    name: name,
-                    is_include_file: is_include_file,
-                    include_path: include_path,
-                    logical_name: logical_name,
-                    is_manual: is_manual,
-                    file_type: file_type,
-                    file_version: file_version
-                };
-
-                prj.add_file(file_definition);
-            });
-
-            if (prj_info.toplevel !== undefined) {
-                const toplevel_path = file_utils.get_absolute_path(file_utils.get_directory(base_path),
-                    prj_info.toplevel);
-                if (file_utils.check_if_path_exist(toplevel_path)) {
-                    prj.add_toplevel_path(toplevel_path);
-                }
-            }
-
-            // // Add watchers
-            // const watcher_list = prj_info.watchers;
-            // watcher_list.forEach((watcher: any) => {
-            //     //Relative path to absolute
-            //     const name = file_utils.get_absolute_path(file_utils.get_directory(base_path), watcher.name);
-
-            //     let is_include_file = false;
-            //     if (file.is_include_file !== undefined) {
-            //         is_include_file = file.is_include_file;
-            //     }
-            //     let include_path = "";
-            //     if (file.include_path !== undefined) {
-            //         include_path = file.include_path;
-            //     }
-            //     let logical_name = "";
-            //     if (file.logical_name !== undefined) {
-            //         logical_name = file.logical_name;
-            //     }
-
-            //     const file_definition: t_file_reduced = {
-            //         name: name,
-            //         is_include_file: is_include_file,
-            //         include_path: include_path,
-            //         logical_name: logical_name
-            //     };
-
-            //     prj.add_file(file_definition);
-            // });
             this.project_manager_list.push(prj);
-
-            this.save();
-            return this.get_sucessful_result(undefined);
-        } catch (error) {
-            return this.get_error_reading_prj();
+            return prj;
         }
     }
 
-    public delete_project(prj_name: string): t_action_result {
+    public create_project(prj_info: any, base_path: string): Project_manager {
+        const prj = this.initialize_project(prj_info.name);
+
+        // Add files
+        const file_list = prj_info.files;
+        file_list.forEach((file: any) => {
+            //Relative path to absolute
+            const name = file_utils.get_absolute_path(file_utils.get_directory(base_path), file.name);
+
+            let is_include_file = false;
+            if (file.is_include_file !== undefined) {
+                is_include_file = file.is_include_file;
+            }
+            let include_path = "";
+            if (file.include_path !== undefined) {
+                include_path = file.include_path;
+            }
+            let logical_name = "";
+            if (file.logical_name !== undefined) {
+                logical_name = file.logical_name;
+            }
+            let is_manual = true;
+            if (file.is_manual !== undefined) {
+                is_manual = file.is_manual;
+            }
+            let file_type = file.file_type;
+            if (file_type === undefined) {
+                file_type = get_language_from_filepath(name);
+            }
+            let file_version = file_utils.check_default_version_for_filepath(name, file.file_version);
+            if (file_version === undefined) {
+                file_version = file_utils.get_default_version_for_filepath(name);
+            }
+
+            const file_definition: t_file = {
+                name: name,
+                is_include_file: is_include_file,
+                include_path: include_path,
+                logical_name: logical_name,
+                is_manual: is_manual,
+                file_type: file_type,
+                file_version: file_version
+            };
+
+            prj.add_file(file_definition);
+        });
+
+        if (prj_info.toplevel !== undefined) {
+            const toplevel_path = file_utils.get_absolute_path(file_utils.get_directory(base_path),
+                prj_info.toplevel);
+            if (file_utils.check_if_path_exist(toplevel_path)) {
+                prj.add_toplevel_path(toplevel_path);
+            }
+        }
+
+        return prj;
+
+    }
+
+    public rename_project(prj: Project_manager, new_name: string): void {
+        try {
+            this.get_project_by_name(new_name);
+            throw new ProjectOperationError(`Project ${new_name} already exists. Please use a different name.`);
+        } catch (error) {
+            prj.rename(new_name);
+        }
+    }
+
+    public delete_project(prj: Project_manager): void {
         const new_project_manager_list: Project_manager[] = [];
 
-        if (prj_name === this.selected_project) {
-            this.selected_project = "";
+        if (prj.get_name() === this.selected_project_name) {
+            this.selected_project_name = "";
         }
 
         let is_prj = false;
         for (let i = 0; i < this.project_manager_list.length; i++) {
             const element = this.project_manager_list[i];
-            if (element.get_name() !== prj_name) {
+            if (element.get_name() !== prj.get_name()) {
                 new_project_manager_list.push(element);
             }
             else {
@@ -320,256 +234,40 @@ export class Multi_project_manager {
             }
         }
         this.project_manager_list = new_project_manager_list;
-        this.save();
-        if (is_prj === true) {
-            return this.get_sucessful_result(undefined);
+
+        if (is_prj === false) {
+            throw new ProjectOperationError(`Project ${prj.get_name()} could not been deleted.`);
         }
-        return this.get_project_not_exist();
     }
 
-    public select_project_current(prj_name: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
+    public set_selected_project(prj: Project_manager): void {
+        if (this.project_manager_list.includes(prj) === true) {
+            this.selected_project_name = prj.get_name();
+            return;
         }
-        this.selected_project = prj_name;
-        this.save();
-        return this.get_sucessful_result(undefined);
-    }
-
-    public get_project_by_name(name: string): Project_manager | undefined {
-        let return_value: Project_manager | undefined = undefined;
-        this.project_manager_list.forEach(project => {
-            if (project.get_name() === name) {
-                return_value = project;
-            }
-        });
-        return return_value;
-    }
-
-    public get_select_project(): t_action_result {
-        const prj = this.get_project_by_name(this.selected_project);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        return this.get_sucessful_result(prj);
+        throw new ProjectOperationError(`Project ${prj.get_name()} is not in the project list.`);
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // Watcher
+    // OLD
     ////////////////////////////////////////////////////////////////////////////
-    public add_file_to_watcher(prj_name: string, watcher: t_watcher): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            this.save();
-            return this.get_project_not_exist();
-        }
-        const result = prj.add_file_to_watcher(watcher);
-        this.save();
-        return result;
+
+    async create_project_from_quartus(prj_path: string): Promise<Project_manager> {
+        const result = await get_project_info_from_quartus(this.get_config_global_config(), prj_path);
+        const prj = this.initialize_project(result.prj_name);
+        await prj.add_file_from_quartus(this.get_config_global_config(), prj_path, true);
+        prj.add_toplevel_path_from_entity(result.prj_top_entity);
+        return prj;
     }
 
-    public delete_file_in_watcher(prj_name: string, watcher_path: string)
-        : t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            this.save();
-            return this.get_project_not_exist();
-        }
-        const result = prj.delete_file_in_watcher(watcher_path);
-        this.save();
-        return result;
+    public create_project_from_json_edam(filepath: string): Project_manager {
+        const prj_info = JSON.parse(file_utils.read_file_sync(filepath));
+        return this.create_project(prj_info, filepath);
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Hook
-    ////////////////////////////////////////////////////////////////////////////
-    // public add_hook(prj_name: string, script: t_script, stage: e_script_stage)
-    //     : t_action_result {
-    //     const prj = this.get_project_by_name(prj_name);
-    //     if (prj === undefined) {
-    //         this.save();
-    //         return this.get_project_not_exist();
-    //     }
-    //     const result = prj.add_hook(script, stage);
-    //     this.save();
-    //     return result;
-    // }
-
-    // public delete_hook(prj_name: string, script: t_script, stage: e_script_stage)
-    //     : t_action_result {
-    //     const prj = this.get_project_by_name(prj_name);
-    //     if (prj === undefined) {
-    //         this.save();
-    //         return this.get_project_not_exist();
-    //     }
-    //     const result = prj.delete_hook(script, stage);
-    //     this.save();
-    //     return result;
-    // }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Parameters
-    ////////////////////////////////////////////////////////////////////////////
-    // add_parameter(prj_name: string, parameter: t_parameter): t_action_result {
-    //     const prj = this.get_project_by_name(prj_name);
-    //     if (prj === undefined) {
-    //         return this.get_project_not_exist();
-    //     }
-    //     const result = prj.add_parameter(parameter);
-    //     this.save();
-    //     return result;
-    // }
-
-    // delete_parameter(prj_name: string, parameter: t_parameter): t_action_result {
-    //     const prj = this.get_project_by_name(prj_name);
-    //     if (prj === undefined) {
-    //         return this.get_project_not_exist();
-    //     }
-    //     const result = prj.delete_parameter(parameter);
-    //     this.save();
-    //     return result;
-    // }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Toplevel
-    ////////////////////////////////////////////////////////////////////////////
-    add_toplevel_path_from_entity(prj_name: string, entity_name: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.add_toplevel_path_from_entity(entity_name);
-        this.save();
-        return result;
-    }
-
-    add_toplevel_path(prj_name: string, toplevel_path_inst: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.add_toplevel_path(toplevel_path_inst);
-        this.save();
-        return result;
-    }
-
-    delete_toplevel_path(prj_name: string, toplevel_path_inst: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.delete_toplevel_path(toplevel_path_inst);
-        this.save();
-        return result;
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // File
-    ////////////////////////////////////////////////////////////////////////////
-    add_logical(prj_name: string, logical_name: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.add_logical(logical_name);
-        this.save();
-        return result;
-    }
-
-    add_file(prj_name: string, file: t_file): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.add_file(file);
-        this.save();
-        return result;
-    }
-
-    add_file_from_csv(prj_name: string, csv_path: string, is_manual: boolean): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.add_file_from_csv(csv_path, is_manual);
-        this.save();
-        return result;
-    }
-
-    async add_file_from_vunit(prj_name: string, general_config: e_config | undefined,
-        vunit_path: string, is_manual: boolean): Promise<t_action_result> {
-
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = await prj.add_file_from_vunit(general_config, vunit_path, is_manual);
-        this.save();
-        return result;
-    }
-
-    async add_file_from_vivado(prj_name: string, general_config: e_config | undefined,
-        vivado_path: string, is_manual: boolean): Promise<t_action_result> {
-
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = await prj.add_file_from_vivado(general_config, vivado_path, is_manual);
-        this.save();
-        return result;
-    }
-
-    async add_file_from_quartus(prj_name: string, general_config: e_config | undefined,
-        prj_path: string, is_manual: boolean): Promise<t_action_result> {
-
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = await prj.add_file_from_quartus(general_config, prj_path, is_manual);
-        this.save();
-        return result;
-    }
-
-    delete_file(prj_name: string, name: string, logical_name = "") {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.delete_file(name, logical_name);
-        this.save();
-        return result;
-    }
-
-    delete_file_by_logical_name(prj_name: string, logical_name: string) {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.delete_file_by_logical_name(logical_name);
-        this.save();
-        return result;
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Dependency
-    ////////////////////////////////////////////////////////////////////////////
-    async get_dependency_graph(prj_name: string, python_path: string): Promise<t_action_result> {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        return await prj.get_dependency_graph(python_path);
-    }
-
-    async get_dependency_tree(prj_name: string, python_path: string): Promise<t_action_result> {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        return prj.get_dependency_tree(python_path);
+    public create_project_from_yaml_edam(filepath: string): Project_manager {
+        const prj_info = yaml.load(file_utils.read_file_sync(filepath));
+        return this.create_project(prj_info, filepath);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -604,89 +302,8 @@ export class Multi_project_manager {
         return this.get_sucessful_result(undefined);
     }
 
-    public set_config(prj_name: string, config: e_config): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        prj.set_config(config);
-        return this.get_sucessful_result(undefined);
-    }
-
-    public get_config(prj_name: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.get_config();
-        return this.get_sucessful_result(result);
-    }
-
     public get_config_global_config() {
         return this.global_config.get_config();
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Tool
-    ////////////////////////////////////////////////////////////////////////////
-    public run(prj_name: string, general_config: e_config | undefined, test_list: t_test_declaration[],
-        callback: (result: t_test_result[]) => void,
-        callback_stream: (stream_c: t_action_result) => void): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            callback([]);
-            return this.get_project_not_exist();
-        }
-        const exec_i = prj.run(general_config, test_list, callback, callback_stream);
-        return this.get_sucessful_result(exec_i);
-    }
-
-    public clean(prj_name: string, general_config: e_config | undefined, clean_mode: e_clean_step,
-        callback_stream: (stream_c: t_action_result) => void): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const exec_i = prj.clean(general_config, clean_mode, callback_stream);
-        return this.get_sucessful_result(exec_i);
-    }
-
-    public async get_test_list(prj_name: string, general_config: e_config): Promise<t_test_declaration[]> {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return [];
-        }
-        return await prj.get_test_list(general_config);
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Utils
-    ////////////////////////////////////////////////////////////////////////////
-    private get_project_not_exist(): t_action_result {
-        const result: t_action_result = {
-            result: undefined,
-            successful: false,
-            msg: "Project doesn't exists"
-        };
-        return result;
-    }
-
-    private get_project_exist(): t_action_result {
-        const result: t_action_result = {
-            result: undefined,
-            successful: false,
-            msg: "Project name exists"
-        };
-        return result;
-    }
-
-    private get_error_reading_prj(): t_action_result {
-        const result: t_action_result = {
-            result: undefined,
-            successful: false,
-            msg: "Error reading the project"
-        };
-        return result;
     }
 
     private get_sucessful_result(result_i: any): t_action_result {
@@ -696,15 +313,6 @@ export class Multi_project_manager {
             msg: ""
         };
         return result;
-    }
-
-    public check_if_file_in_project(prj_name: string, name: string, logical_name: string): t_action_result {
-        const prj = this.get_project_by_name(prj_name);
-        if (prj === undefined) {
-            return this.get_project_not_exist();
-        }
-        const result = prj.check_if_file_in_project(name, logical_name);
-        return this.get_sucessful_result(result);
     }
 
 }

--- a/packages/teroshdl/src/features/dependency.ts
+++ b/packages/teroshdl/src/features/dependency.ts
@@ -34,8 +34,8 @@ export class Dependency_manager {
     protected panel: vscode.WebviewPanel | undefined;
     protected manager: t_Multi_project_manager;
     private init: boolean = false;
-    private viz : any = undefined;
-    private dependencies : string = "";
+    private viz: any = undefined;
+    private dependencies: string = "";
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -73,7 +73,7 @@ export class Dependency_manager {
 
         const html = nunjucks.renderString(template_str, {
             'css_bootstrap_path': css_bootstrap_path,
-            "css_common_path": css_common_path, 
+            "css_common_path": css_common_path,
             "cspSource": webview.cspSource,
             "js_path_0": js_path_0,
             "js_path_1": js_path_1,

--- a/packages/teroshdl/src/features/dependency.ts
+++ b/packages/teroshdl/src/features/dependency.ts
@@ -135,24 +135,21 @@ export class Dependency_manager {
         if (this.panel === undefined) {
             return;
         }
-        const selected_project = this.manager.get_select_project();
-        if (selected_project.successful === false) {
-            this.logger.error("Selecte a project first.", false);
+        try {
+            const selected_project = this.manager.get_selected_project();
+            const python_path = this.manager.get_config_manager().get_config().general.general.pypath;
+            const result = await selected_project.get_dependency_graph(python_path);
+            if (result.successful === false) {
+                this.logger.error("Error while getting dependency graph.", true);
+                this.logger.error(result.msg, true);
+                return "";
+            }
+            this.dependencies = result.result;
+            await this.panel?.webview.postMessage({ command: "update", message: result.result });
+        } catch (error) {
+            this.logger.error("Select a project first.", false);
             return "";
         }
-
-        const python_path = this.manager.get_config_manager().get_config().general.general.pypath;
-
-        const result = await (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result)
-            .get_dependency_graph(python_path);
-
-        if (result.successful === false) {
-            this.logger.error("Error while getting dependency graph.", true);
-            this.logger.error(result.msg, true);
-            return "";
-        }
-        this.dependencies = result.result;
-        await this.panel?.webview.postMessage({ command: "update", message: result.result });
     }
 
     async export_as() {

--- a/packages/teroshdl/src/features/schematic.ts
+++ b/packages/teroshdl/src/features/schematic.ts
@@ -43,19 +43,19 @@ export class Schematic_manager extends Base_webview {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    constructor(context: vscode.ExtensionContext, logger: Logger, manager: t_Multi_project_manager, 
+    constructor(context: vscode.ExtensionContext, logger: Logger, manager: t_Multi_project_manager,
         mode_project: boolean) {
 
-        super(context, manager, path_lib.join(context.extensionPath, 'resources', 'webviews', 
+        super(context, manager, path_lib.join(context.extensionPath, 'resources', 'webviews',
             'netlist_viewer', 'netlist_viewer.html'), activation_command, id);
-        
+
         this.working_directory = os.tmpdir();
         this.output_path = path_lib.join(this.working_directory, 'teroshdl_yosys_output.json');
         this.logger = logger;
     }
 
-    get_webview_content(webview: vscode.Webview){
-        const template_path = path_lib.join(this.context.extensionPath, 'resources','webviews', 'netlist_viewer', 'index.html.nj');
+    get_webview_content(webview: vscode.Webview) {
+        const template_path = path_lib.join(this.context.extensionPath, 'resources', 'webviews', 'netlist_viewer', 'index.html.nj');
         const template_str = fs.readFileSync(template_path, 'utf-8');
 
         const css_bootstrap_path = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews', 'common',
@@ -63,26 +63,26 @@ export class Schematic_manager extends Base_webview {
         const css_common_path = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews', 'common',
             'style.css'));
 
-        const css_path = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews', 
+        const css_path = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'style.css'));
-        const js_path_0 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews', 
+        const js_path_0 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'libs', 'elk.bundled.js'));
-        const js_path_1 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews', 
+        const js_path_1 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'libs', 'netlistsvg.bundle.js'));
-        const js_path_2 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews', 
+        const js_path_2 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'libs', 'jquery-2.2.4.min.js'));
-        const js_path_3 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews',
+        const js_path_3 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'libs', 'svg-pan-zoom.min.js'));
-        const js_path_4 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews',
+        const js_path_4 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'libs', 'viz.js'));
-        const js_path_5 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources','webviews',
+        const js_path_5 = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'resources', 'webviews',
             'netlist_viewer', 'libs', 'main.js'));
 
         const html = nunjucks.renderString(template_str, {
             "css_common_path": css_common_path,
-            "css_bootstrap_path": css_bootstrap_path, 
-            "css_path": css_path, 
-            "cspSource": webview.cspSource, 
+            "css_bootstrap_path": css_bootstrap_path,
+            "css_path": css_path,
+            "cspSource": webview.cspSource,
             "js_path_0": js_path_0,
             "js_path_1": js_path_1,
             "js_path_2": js_path_2,
@@ -138,7 +138,7 @@ export class Schematic_manager extends Base_webview {
             }
             await this.update(document);
         }
-        else{
+        else {
             await this.generate_project_netlist();
         }
     }
@@ -160,7 +160,7 @@ export class Schematic_manager extends Base_webview {
         await this.panel?.webview.postMessage({ command: "update", result: result });
 
     }
-    
+
     //////////////////////////////////////////////////////////////////////////////
     // Export
     //////////////////////////////////////////////////////////////////////////////
@@ -187,7 +187,7 @@ export class Schematic_manager extends Base_webview {
         } catch (err) { }
     }
 
-    async generate_project_netlist() {  
+    async generate_project_netlist() {
         vscode.window.withProgress({
             location: vscode.ProgressLocation.Window,
             cancellable: false,
@@ -288,7 +288,7 @@ export class Schematic_manager extends Base_webview {
         }
         let output_path_filename = path_lib.basename(output_path);
         let top_level_cmd = "";
-        if (top_level !== ""){
+        if (top_level !== "") {
             top_level_cmd = `hierarchy -top ${top_level}`;
         }
         const script_code = `${cmd_files}; ${top_level_cmd}; proc; ${custom_argumens} ; write_json ${output_path_filename}; stat`;
@@ -298,8 +298,8 @@ export class Schematic_manager extends Base_webview {
             plugin = `-m ghdl`;
         }
         let command = `${extra} yowasp-yosys -p "${script_code}"`;
-        if (backend === teroshdl2.config.config_declaration.e_schematic_general_backend.yosys 
-            || backend === teroshdl2.config.config_declaration.e_schematic_general_backend.yosys_ghdl 
+        if (backend === teroshdl2.config.config_declaration.e_schematic_general_backend.yosys
+            || backend === teroshdl2.config.config_declaration.e_schematic_general_backend.yosys_ghdl
             || backend === teroshdl2.config.config_declaration.e_schematic_general_backend.yosys_ghdl_module) {
             if (yosys_path === '') {
                 yosys_path = 'yosys';
@@ -353,7 +353,7 @@ export class Schematic_manager extends Base_webview {
     async get_svg_from_json(output_yosys) {
         output_yosys.result = yosys.normalize_netlist(output_yosys.result);
         const netlistsvg = require("netlistsvg");
-        const skinPath = path_lib.join(this.context.extensionPath, "resources", 
+        const skinPath = path_lib.join(this.context.extensionPath, "resources",
             "webviews", "netlist_viewer", "default.svg");
         const skin = fs.readFileSync(skinPath);
 

--- a/packages/teroshdl/src/features/schematic.ts
+++ b/packages/teroshdl/src/features/schematic.ts
@@ -232,31 +232,30 @@ export class Schematic_manager extends Base_webview {
     }
 
     async generate_from_project() {
-        const selected_project = this.manager.get_select_project();
-        if (selected_project.successful === false) {
-            this.logger.error("Selecte a project first.", false);
+        try {
+            const selected_project = this.manager.get_selected_project();
+            const sources = selected_project.get_project_definition().file_manager.get();
+
+            const file_array: string[] = [];
+            sources.forEach(source_inst => {
+                file_array.push(source_inst.name);
+            });
+
+            this.clear_enviroment(this.output_path);
+
+            const top_level_path = selected_project.get_project_definition().toplevel_path_manager.get();
+
+            let top_level = "";
+            if (top_level_path.length === 1) {
+                top_level = teroshdl2.utils.hdl.get_toplevel_from_path(top_level_path[0]);
+            }
+
+            return await this.run_yosys_script(top_level, file_array, this.output_path);
+        } catch (error) {
+            this.logger.error("Select a project first.", false);
             return "";
         }
 
-        const sources = (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result)
-            .get_project_definition().file_manager.get();
-
-        const file_array : string[] = [];
-        sources.forEach(source_inst => {
-            file_array.push(source_inst.name);
-        });
-
-        this.clear_enviroment(this.output_path);
-
-        const top_level_path = (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result)
-        .get_project_definition().toplevel_path_manager.get();
-
-        let top_level = "";
-        if (top_level_path.length === 1){
-            top_level = teroshdl2.utils.hdl.get_toplevel_from_path(top_level_path[0]);
-        }
-
-        return await this.run_yosys_script(top_level, file_array, this.output_path);
     }
 
     async generate_from_file(file_path: string) {

--- a/packages/teroshdl/src/features/tree_views/dependency/element.ts
+++ b/packages/teroshdl/src/features/tree_views/dependency/element.ts
@@ -94,19 +94,19 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         if (element) {
             toplevel_path = element.get_path();
         }
-        else{
+        else {
             const current_top = await this.get_toplevel_path();
-            if (current_top === undefined){
+            if (current_top === undefined) {
                 return [];
             }
             toplevel_path = current_top;
         }
 
         // Dependencies
-        if (this.hdl_tree === undefined){
+        if (this.hdl_tree === undefined) {
             return [];
         }
-        let current_dep : any = undefined;
+        let current_dep: any = undefined;
         for (let i = 0; i < this.hdl_tree.length; i++) {
             const element = this.hdl_tree[i];
             if (element.filename === toplevel_path) {
@@ -114,7 +114,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
             }
         }
         // const current_dep = await this.get_deps(toplevel_path);
-        if (current_dep === undefined){
+        if (current_dep === undefined) {
             return [];
         }
 
@@ -124,7 +124,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         if (element) {
             return dependency_view;
         }
-        else{
+        else {
             return [new Dependency((<any>current_dep).filename, (<any>current_dep).entity, dependency_view)];
         }
     }
@@ -169,7 +169,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         let current_dep = undefined;
         const hdl_tree = await this.get_hdl_tree();
 
-        if (hdl_tree === undefined){
+        if (hdl_tree === undefined) {
             return undefined;
         }
         this.current_hdl_tree = hdl_tree;
@@ -182,7 +182,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         return current_dep;
     }
 
-    get_dep_view(deps){
+    get_dep_view(deps) {
         const dependency_view: Dependency[] = [];
         if (deps.dependencies !== undefined) {
             deps.dependencies.forEach(dep => {
@@ -195,7 +195,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     async refresh() {
         // Toplevel path
         const toplevel_path = await this.get_toplevel_path();
-        if (toplevel_path === undefined){
+        if (toplevel_path === undefined) {
             this.data = [];
             this._onDidChangeTreeData.fire();
             return;
@@ -203,7 +203,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
 
         // Dependencies
         const current_dep = await this.get_deps(toplevel_path);
-        if (current_dep === undefined){
+        if (current_dep === undefined) {
             this.data = [];
             this._onDidChangeTreeData.fire();
             return;

--- a/packages/teroshdl/src/features/tree_views/dependency/element.ts
+++ b/packages/teroshdl/src/features/tree_views/dependency/element.ts
@@ -137,32 +137,31 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     // Utils
     //////////////////////////////////////////////////////////////////////////////////////////////
     async get_hdl_tree() {
-        const selected_project = this.project_manager.get_select_project();
-        if (selected_project.successful === false) {
+        try {
+            const selected_project = this.project_manager.get_selected_project();
+            const python_path = this.project_manager.get_config_global_config().general.general.pypath;
+            const result = await selected_project.get_dependency_tree(python_path);
+            if (result.successful === true) {
+                this.hdl_tree = result.result;
+                return this.hdl_tree;
+            }
+            return undefined;
+        } catch (error) {
             return undefined;
         }
-
-        const python_path = this.project_manager.get_config_global_config().general.general.pypath;
-        const result = await (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result)
-            .get_dependency_tree(python_path);
-        if (result.successful === true) {
-            this.hdl_tree = result.result;
-            return this.hdl_tree;
-        }
-        return undefined;
     }
 
     async get_toplevel_path() {
-        const selected_project = this.project_manager.get_select_project();
-        if (selected_project.successful === false) {
+        try {
+            const selected_project = this.project_manager.get_selected_project();
+            const toplevel = await selected_project.get_project_definition().toplevel_path_manager.get();
+            if (toplevel.length > 0) {
+                return toplevel[0];
+            }
+            return undefined;
+        } catch (error) {
             return undefined;
         }
-        const toplevel = await (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result)
-            .get_project_definition().toplevel_path_manager.get();
-        if (toplevel.length > 0) {
-            return toplevel[0];
-        }
-        return undefined;
     }
 
     private async get_deps(top_path: string) {

--- a/packages/teroshdl/src/features/tree_views/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/manager.ts
@@ -93,72 +93,73 @@ export class Tree_view_manager {
         output_manager.refresh_tree();
         tree_manager.refresh_tree();
 
-        // Save toml
-        const selected_prj = multi_manager.get_select_project();
-        if (selected_prj.successful === false) {
-            return;
-        }
-        const select_project = (<teroshdl.project_manager.project_manager.Project_manager>selected_prj.result);
-        const prj_sources = select_project.get_project_definition().file_manager.get();
+        try {
+            // Save toml
+            const select_project = multi_manager.get_selected_project();
+            const prj_sources = select_project.get_project_definition().file_manager.get();
 
-        type t_lib = {
-            name: string,
-            files: string[]
-        };
+            type t_lib = {
+                name: string,
+                files: string[]
+            };
 
-        let libraries: t_lib[] = [];
+            let libraries: t_lib[] = [];
 
-        for (let i = 0; i < prj_sources.length; i++) {
-            const source = prj_sources[i];
+            for (let i = 0; i < prj_sources.length; i++) {
+                const source = prj_sources[i];
 
-            // Check if file in library
-            let file_in_library = false;
-            for (let j = 0; j < libraries.length; j++) {
-                const library = libraries[j];
-                if (library.name === source.logical_name) {
-                    file_in_library = true;
-                    library.files.push(source.name);
-                    break;
-                }
-            }
-            if (file_in_library === false) {
-                let new_library: t_lib = {
-                    name: source.logical_name,
-                    files: [source.name]
-                };
-                libraries.push(new_library);
-            }
-        }
-
-        let files_toml: string[] = [];
-        let file_path = path_lib.join(os.homedir(), ".vhdl_ls.toml");
-        let toml = "[libraries]\n\n";
-        if (libraries !== undefined) {
-            for (let i = 0; i < libraries.length; i++) {
-                let library = libraries[i];
-                let files_in_library = "";
-                for (let j = 0; j < library.files.length; j++) {
-                    const file_in_library = library.files[j];
-                    let filename = path_lib.basename(file_in_library);
-                    const lang = teroshdl.utils.file.get_language_from_filepath(filename);
-                    if (lang === teroshdl.common.general.LANGUAGE.VHDL) {
-                        files_in_library += `  '${file_in_library}',\n`;
-                        files_toml.push(file_in_library);
+                // Check if file in library
+                let file_in_library = false;
+                for (let j = 0; j < libraries.length; j++) {
+                    const library = libraries[j];
+                    if (library.name === source.logical_name) {
+                        file_in_library = true;
+                        library.files.push(source.name);
+                        break;
                     }
                 }
-                let lib_name = library.name;
-                if (lib_name === "") {
-                    lib_name = "none";
+                if (file_in_library === false) {
+                    let new_library: t_lib = {
+                        name: source.logical_name,
+                        files: [source.name]
+                    };
+                    libraries.push(new_library);
                 }
-                if (library.name === undefined || library.name === '') {
-                    library.name = 'work';
-                }
-                toml += `${library.name}.files = [\n${files_in_library}]\n\n`;
             }
+
+            let files_toml: string[] = [];
+            let file_path = path_lib.join(os.homedir(), ".vhdl_ls.toml");
+            let toml = "[libraries]\n\n";
+            if (libraries !== undefined) {
+                for (let i = 0; i < libraries.length; i++) {
+                    let library = libraries[i];
+                    let files_in_library = "";
+                    for (let j = 0; j < library.files.length; j++) {
+                        const file_in_library = library.files[j];
+                        let filename = path_lib.basename(file_in_library);
+                        const lang = teroshdl.utils.file.get_language_from_filepath(filename);
+                        if (lang === teroshdl.common.general.LANGUAGE.VHDL) {
+                            files_in_library += `  '${file_in_library}',\n`;
+                            files_toml.push(file_in_library);
+                        }
+                    }
+                    let lib_name = library.name;
+                    if (lib_name === "") {
+                        lib_name = "none";
+                    }
+                    if (library.name === undefined || library.name === '') {
+                        library.name = 'work';
+                    }
+                    toml += `${library.name}.files = [\n${files_in_library}]\n\n`;
+                }
+            }
+            teroshdl.utils.file.save_file_sync(file_path, toml);
+            vscode.commands.executeCommand("teroshdl.vhdlls.restart");
+            return files_toml;
+
+        } catch (error) {
+            return;
         }
-        teroshdl.utils.file.save_file_sync(file_path, toml);
-        vscode.commands.executeCommand("teroshdl.vhdlls.restart");
-        return files_toml;
     }
 
     // prj_loading(slm: any){

--- a/packages/teroshdl/src/features/tree_views/output/element.ts
+++ b/packages/teroshdl/src/features/tree_views/output/element.ts
@@ -171,34 +171,34 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     }
 
     async refresh(): Promise<void> {
-        const selected_project = this.project_manager.get_select_project();
-        if (selected_project.successful === false) {
+        try {
+            this.project_manager.get_selected_project();
+            const runs_view: Output[] = [];
+
+            const result_list = this.run_output_manager.get_results();
+            result_list.forEach(result => {
+                const artifact_list: Output[] = [];
+                result.artifact.forEach(artifact => {
+                    artifact_list.push(new Output(artifact.name, artifact.path, undefined, artifact.artifact_type,
+                        artifact.element_type, artifact.content, undefined));
+                });
+                if (artifact_list.length !== 0) {
+                    runs_view.push(new Output(result.name, result.name, result.successful, undefined, undefined,
+                        "", result.time, artifact_list));
+                }
+                else {
+                    runs_view.push(new Output(result.name, result.name, result.successful, undefined, undefined, "",
+                        result.time));
+                }
+            });
+
+            this.data = runs_view;
+            this._onDidChangeTreeData.fire();
+        } catch (error) {
             this.data = [];
             this._onDidChangeTreeData.fire();
             return;
         }
-
-        const runs_view: Output[] = [];
-
-        const result_list = this.run_output_manager.get_results();
-        result_list.forEach(result => {
-            const artifact_list: Output[] = [];
-            result.artifact.forEach(artifact => {
-                artifact_list.push(new Output(artifact.name, artifact.path, undefined, artifact.artifact_type, 
-                    artifact.element_type, artifact.content, undefined));
-            });
-            if (artifact_list.length !== 0){
-                runs_view.push(new Output(result.name, result.name, result.successful, undefined, undefined, 
-                    "", result.time, artifact_list));
-            }
-            else{
-                runs_view.push(new Output(result.name, result.name, result.successful, undefined, undefined, "",
-                    result.time));
-            }
-        });
-
-        this.data = runs_view;
-        this._onDidChangeTreeData.fire();
     }
 
     get_successful(name: string) {

--- a/packages/teroshdl/src/features/tree_views/output/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/output/manager.ts
@@ -20,17 +20,17 @@
 import * as vscode from "vscode";
 import * as element from "./element";
 import { t_Multi_project_manager } from '../../../type_declaration';
-import {e_clean_step} from 'teroshdl2/out/project_manager/tool/common';
+import { e_clean_step } from 'teroshdl2/out/project_manager/tool/common';
 
 import * as teroshdl2 from 'teroshdl2';
 import { Run_output_manager } from "../run_output";
-import {Logger} from "../../../logger";
+import { Logger } from "../../../logger";
 
 export class Output_manager {
     private tree: element.ProjectProvider;
     private run_output_manager: Run_output_manager;
-    private project_manager : t_Multi_project_manager;
-    private logger : Logger;
+    private project_manager: t_Multi_project_manager;
+    private logger: Logger;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -67,7 +67,7 @@ export class Output_manager {
 
     async clean() {
         const tool_name = this.project_manager.get_config_global_config().tools.general.select_tool;
-        if (tool_name !== teroshdl2.config.config_declaration.e_tools_general_select_tool.raptor){
+        if (tool_name !== teroshdl2.config.config_declaration.e_tools_general_select_tool.raptor) {
             return;
         }
 
@@ -76,7 +76,7 @@ export class Output_manager {
             placeHolder: "Select stage.",
         });
 
-        if (picker_value === undefined){
+        if (picker_value === undefined) {
             return;
         }
 
@@ -100,7 +100,7 @@ export class Output_manager {
         );
     }
 
-    get_step_enum(value: string) : e_clean_step{
+    get_step_enum(value: string): e_clean_step {
         const indexOfS = Object.values(e_clean_step).indexOf(value as unknown as e_clean_step);
         const key = Object.keys(e_clean_step)[indexOfS];
         return <e_clean_step>key;

--- a/packages/teroshdl/src/features/tree_views/output/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/output/manager.ts
@@ -54,17 +54,6 @@ export class Output_manager {
         this.tree.refresh();
     }
 
-    get_selected_project_name(): string | undefined {
-        const selected_prj = this.project_manager.get_select_project();
-        // No project select
-        if (selected_prj.successful === false) {
-            return undefined;
-        }
-        else {
-            return (<teroshdl2.project_manager.project_manager.Project_manager>selected_prj.result).get_name();
-        }
-    }
-
     async clean() {
         const tool_name = this.project_manager.get_config_global_config().tools.general.select_tool;
         if (tool_name !== teroshdl2.config.config_declaration.e_tools_general_select_tool.raptor) {
@@ -80,24 +69,24 @@ export class Output_manager {
             return;
         }
 
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined){
+        try {
+            const prj = this.project_manager.get_selected_project();
+            const selfm = this;
+            const step = this.get_step_enum(picker_value);
+            prj.clean(this.project_manager.get_config_global_config(),
+                step,
+                (function (stream_c: any) {
+                    stream_c.stdout.on('data', function (data: any) {
+                        selfm.logger.log(data);
+                    });
+                    stream_c.stderr.on('data', function (data: any) {
+                        selfm.logger.log(data);
+                    });
+                }),
+            );
+        } catch (error) {
             return;
         }
-
-        const selfm = this;
-        const step = this.get_step_enum(picker_value);
-        this.project_manager.clean(prj_name, this.project_manager.get_config_global_config(), 
-        step,
-            (function (stream_c: any) {
-                stream_c.stdout.on('data', function (data: any) {
-                    selfm.logger.log(data);
-                });
-                stream_c.stderr.on('data', function (data: any) {
-                    selfm.logger.log(data);
-                });
-            }),
-        );
     }
 
     get_step_enum(value: string): e_clean_step {

--- a/packages/teroshdl/src/features/tree_views/project/element.ts
+++ b/packages/teroshdl/src/features/tree_views/project/element.ts
@@ -19,7 +19,7 @@
 
 import { Multi_project_manager } from "teroshdl2/out/project_manager/multi_project_manager";
 import * as vscode from "vscode";
-import {get_icon} from "../utils";
+import { get_icon } from "../utils";
 
 
 export const VIEW_ID = "teroshdl-project";
@@ -52,7 +52,7 @@ export class Project extends vscode.TreeItem {
         };
     }
 
-    public get_project_name() : string{
+    public get_project_name(): string {
         return this.project_name;
     }
 }
@@ -70,14 +70,14 @@ export abstract class BaseTreeDataProvider<T> implements vscode.TreeDataProvider
 }
 
 export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
-    
+
     private _onDidChangeTreeData: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     readonly onDidChangeTreeData: vscode.Event<void> = this._onDidChangeTreeData.event;
 
     data: TreeItem[] = [];
-    private project_manager : Multi_project_manager;
+    private project_manager: Multi_project_manager;
 
-    constructor(project_manager : Multi_project_manager) {
+    constructor(project_manager: Multi_project_manager) {
         super();
         this.project_manager = project_manager;
     }
@@ -98,7 +98,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     }
 
     refresh(): void {
-        const prj_view : Project[]= [];
+        const prj_view: Project[] = [];
 
         const project_list = this.project_manager.get_projects();
         const selected_project = this.project_manager.get_select_project();

--- a/packages/teroshdl/src/features/tree_views/project/element.ts
+++ b/packages/teroshdl/src/features/tree_views/project/element.ts
@@ -101,15 +101,15 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         const prj_view: Project[] = [];
 
         const project_list = this.project_manager.get_projects();
-        const selected_project = this.project_manager.get_select_project();
         let selected_project_name = '';
-        if (selected_project.successful === true){
-            selected_project_name = selected_project.result.name;
+        try {
+            selected_project_name = this.project_manager.get_selected_project().get_name();
+        } catch (error) {
         }
         project_list.forEach(prj => {
             const prj_name = prj.get_name();
             let label = prj.get_name();
-            if (selected_project_name === prj_name){
+            if (selected_project_name === prj_name) {
                 label = `${prj_name} (current)`;
             }
             prj_view.push(new Project(prj.get_name(), label));

--- a/packages/teroshdl/src/features/tree_views/project/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/project/manager.ts
@@ -93,8 +93,10 @@ export class Project_manager {
             // Create project
             const project_name = await utils.get_from_input_box("Set the project name", "Project name");
             if (project_name !== undefined) {
-                this.project_manager.create_project(project_name);
-                this.refresh();
+                try {
+                    this.project_manager.initialize_project(project_name);
+                } catch (error) {
+                }
             }
         }
         // Load from JSON EDAM
@@ -118,9 +120,11 @@ export class Project_manager {
             // Create project
             const project_name = await utils.get_from_input_box("Set the project name", "Project name");
             if (project_name !== undefined) {
-                this.project_manager.create_project(project_name);
-                await utils.add_sources_from_vunit(this.project_manager, project_name, true);
-                this.refresh();
+                try {
+                    const prj = this.project_manager.initialize_project(project_name);
+                    await utils.add_sources_from_vunit(prj, this.project_manager.get_config_global_config(), true);
+                } catch (error) {
+                }
             }
         }
         // Load an example
@@ -191,44 +195,64 @@ export class Project_manager {
             const rsult = teroshdl2.project_manager.quartus.create_quartus_project(this.project_manager.get_config_global_config(), working_directory[0],
                 project_name, picker_family, picker_part);
         }
+        this.refresh();
     }
 
-    async create_project_from_quartus(prj_path : string){
-        await this.project_manager.create_project_from_quartus(this.project_manager.get_config_global_config(), prj_path);
-        this.refresh();
+    async create_project_from_quartus(prj_path: string) {
+        try {
+            await this.project_manager.create_project_from_quartus(prj_path);
+            this.refresh();
+        } catch (error) {
+        }
     }
-    
-    create_project_from_json(prj_path : string){
-        this.project_manager.create_project_from_json_edam(prj_path);
-        this.refresh();
+
+    create_project_from_json(prj_path: string) {
+        try {
+            this.project_manager.create_project_from_json_edam(prj_path);
+            this.refresh();
+        } catch (error) {
+        }
     }
 
     create_project_from_yaml(prj_path: string) {
-        this.project_manager.create_project_from_yaml_edam(prj_path);
-        this.refresh();
+        try {
+            this.project_manager.create_project_from_yaml_edam(prj_path);
+            this.refresh();
+        } catch (error) {
+        }
     }
 
-    select_project(item: element.Project){
-        this.project_manager.select_project_current(item.get_project_name());
-        this.run_output_manager.clear();
-        this.refresh();
+    select_project(item: element.Project) {
+        try {
+            this.project_manager.set_selected_project(this.project_manager.get_project_by_name(item.get_project_name()));
+            this.run_output_manager.clear();
+            this.refresh();
+        } catch (error) {
+        }
     }
 
-    delete_project(item: element.Project){
-        this.project_manager.delete_project(item.get_project_name());
-        this.refresh();
+    delete_project(item: element.Project) {
+        try {
+            this.project_manager.delete_project(this.project_manager.get_project_by_name(item.get_project_name()));
+            this.refresh();
+        } catch (error) {
+        }
     }
 
     async rename_project(item: element.Project) {
         const new_project_name = await utils.get_from_input_box("New project name", "Project name");
         if (new_project_name !== undefined) {
-            this.project_manager.rename_project(item.get_project_name(), new_project_name);
-            this.refresh();
+            try {
+                this.project_manager.rename_project(this.project_manager.get_project_by_name(item.get_project_name()), new_project_name);
+                this.refresh();
+            } catch (error) {
+            }
         }
     }
 
     refresh() {
         this.emitter.emit('refresh');
+        this.project_manager.save();
     }
 
     refresh_tree() {

--- a/packages/teroshdl/src/features/tree_views/project/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/project/manager.ts
@@ -23,22 +23,22 @@ import { t_Multi_project_manager } from '../../../type_declaration';
 import * as teroshdl2 from 'teroshdl2';
 import * as events from "events";
 import * as utils from "../utils";
-import {Run_output_manager} from "../run_output";
-import {Logger} from "../../../logger";
+import { Run_output_manager } from "../run_output";
+import { Logger } from "../../../logger";
 
 export class Project_manager {
-    private tree : element.ProjectProvider;
-    private project_manager : t_Multi_project_manager;
-    private emitter : events.EventEmitter;
-    private run_output_manager : Run_output_manager;
-    private context : vscode.ExtensionContext;
+    private tree: element.ProjectProvider;
+    private project_manager: t_Multi_project_manager;
+    private emitter: events.EventEmitter;
+    private run_output_manager: Run_output_manager;
+    private context: vscode.ExtensionContext;
     private global_logger: Logger;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter : events.EventEmitter,
-        run_output_manager: Run_output_manager, global_logger : Logger) {
+    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter: events.EventEmitter,
+        run_output_manager: Run_output_manager, global_logger: Logger) {
         this.set_commands();
 
         this.global_logger = global_logger;
@@ -48,7 +48,7 @@ export class Project_manager {
         this.run_output_manager = run_output_manager;
 
         this.context = context;
-        
+
         context.subscriptions.push(vscode.window.registerTreeDataProvider(element.ProjectProvider.getViewID(), this.tree as element.BaseTreeDataProvider<element.Project>));
         vscode.commands.registerCommand("teroshdl.documentation", () => this.open_doc());
         vscode.commands.registerCommand("teroshdl.view.project.configuration", () => this.config());
@@ -59,11 +59,11 @@ export class Project_manager {
         vscode.commands.executeCommand("teroshdl.configuration");
     }
 
-    open_doc(){
+    open_doc() {
         vscode.env.openExternal(vscode.Uri.parse('https://terostechnology.github.io/terosHDLdoc/'));
     }
 
-    set_commands(){
+    set_commands() {
         vscode.commands.registerCommand("teroshdl.view.project.add", (item) => this.add_project(item));
         vscode.commands.registerCommand("teroshdl.view.project.select", (item) => this.select_project(item));
         vscode.commands.registerCommand("teroshdl.view.project.delete", (item) => this.delete_project(item));
@@ -73,11 +73,11 @@ export class Project_manager {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Project
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    async add_project(item: element.Project){
+    async add_project(item: element.Project) {
         const PROJECT_ADD_TYPES = [
-            "Empty project", 
-            "Load project from JSON EDAM", 
-            "Load project from YAML EDAM", 
+            "Empty project",
+            "Load project from JSON EDAM",
+            "Load project from YAML EDAM",
             "Load project from VUnit run.py",
             "Load an example project",
             "Load Intel® Quartus® Prime project",
@@ -98,23 +98,23 @@ export class Project_manager {
             }
         }
         // Load from JSON EDAM
-        else if(picker_value === PROJECT_ADD_TYPES[1]){
-            const path_list = await utils.get_from_open_dialog("Load project", false, true, true, 
-                "Select JSON EDAM files", {'JSON files (*.json, *.JSON)': ['json', 'JSON']});
+        else if (picker_value === PROJECT_ADD_TYPES[1]) {
+            const path_list = await utils.get_from_open_dialog("Load project", false, true, true,
+                "Select JSON EDAM files", { 'JSON files (*.json, *.JSON)': ['json', 'JSON'] });
             path_list.forEach(path => {
                 this.create_project_from_json(path);
             });
         }
         // Load from YAML EDAM
-        else if(picker_value === PROJECT_ADD_TYPES[2]){
-            const path_list = await utils.get_from_open_dialog("Load project", false, true, true, 
-                "Select YAML EDAM files", {'YAML files (*.yaml, *.yml)': ['yaml', 'yml']});
+        else if (picker_value === PROJECT_ADD_TYPES[2]) {
+            const path_list = await utils.get_from_open_dialog("Load project", false, true, true,
+                "Select YAML EDAM files", { 'YAML files (*.yaml, *.yml)': ['yaml', 'yml'] });
             path_list.forEach(path => {
                 this.create_project_from_yaml(path);
             });
         }
         // Load from VUnit
-        else if(picker_value === PROJECT_ADD_TYPES[3]){
+        else if (picker_value === PROJECT_ADD_TYPES[3]) {
             // Create project
             const project_name = await utils.get_from_input_box("Set the project name", "Project name");
             if (project_name !== undefined) {
@@ -124,10 +124,10 @@ export class Project_manager {
             }
         }
         // Load an example
-        else if(picker_value === PROJECT_ADD_TYPES[4]){
+        else if (picker_value === PROJECT_ADD_TYPES[4]) {
             const project_examples_types = ['Documenter examples', 'State machine examples',
                 'Xsim', 'GHDL', 'Icarus', 'IceStorm', 'ModelSim',
-                'Vivado', 'Yosys', 'VUnit', 'cocotb', 'raptor_counter', 'raptor_counter_vhdl', 
+                'Vivado', 'Yosys', 'VUnit', 'cocotb', 'raptor_counter', 'raptor_counter_vhdl',
                 'raptor_aes_decrypt_fpga', 'raptor_and2_gemini'];
             let picker_value = await vscode.window.showQuickPick(project_examples_types, {
                 placeHolder: "Choose an example project.",
@@ -140,24 +140,24 @@ export class Project_manager {
                     picker_value = 'state_machine';
                 }
 
-                const project_path = path_lib.join(this.context.extensionUri.fsPath, "resources", 
+                const project_path = path_lib.join(this.context.extensionUri.fsPath, "resources",
                     "project_manager", "examples", picker_value.toLowerCase(), 'project.yml');
                 this.create_project_from_yaml(project_path);
             }
         }
         // Load from Quartus
-        else if(picker_value === PROJECT_ADD_TYPES[5]){
-            const path_list = await utils.get_from_open_dialog("Load Quartus project", false, true, false, 
+        else if (picker_value === PROJECT_ADD_TYPES[5]) {
+            const path_list = await utils.get_from_open_dialog("Load Quartus project", false, true, false,
                 "Select Quartus project", { 'Quartus project (*.qsf)': ['qsf'] });
             for (const path of path_list) {
                 this.create_project_from_quartus(path);
             }
         }
-        else if(picker_value === PROJECT_ADD_TYPES[6]){
+        else if (picker_value === PROJECT_ADD_TYPES[6]) {
             // Working directory
-            const working_directory = await 
-                utils.get_from_open_dialog("What is the working directory for this project?", true, false, false, 
-                "Choose", {});
+            const working_directory = await
+                utils.get_from_open_dialog("What is the working directory for this project?", true, false, false,
+                    "Choose", {});
             if (working_directory.length !== 1) {
                 return;
             }
@@ -203,7 +203,7 @@ export class Project_manager {
         this.refresh();
     }
 
-    create_project_from_yaml(prj_path : string){
+    create_project_from_yaml(prj_path: string) {
         this.project_manager.create_project_from_yaml_edam(prj_path);
         this.refresh();
     }
@@ -219,7 +219,7 @@ export class Project_manager {
         this.refresh();
     }
 
-    async rename_project(item: element.Project){
+    async rename_project(item: element.Project) {
         const new_project_name = await utils.get_from_input_box("New project name", "Project name");
         if (new_project_name !== undefined) {
             this.project_manager.rename_project(item.get_project_name(), new_project_name);
@@ -227,21 +227,21 @@ export class Project_manager {
         }
     }
 
-    refresh(){
+    refresh() {
         this.emitter.emit('refresh');
     }
 
-    refresh_tree(){
+    refresh_tree() {
         this.tree.refresh();
     }
 
-    get_doc_msg(msg_url: string){
+    get_doc_msg(msg_url: string) {
         const doc_msg = `Check the documentation to install it: ${msg_url}`;
         return doc_msg;
     }
 
-    async check_dependencies(){
-        const options : teroshdl2.process.python.python_options = {
+    async check_dependencies() {
+        const options: teroshdl2.process.python.python_options = {
             path: this.project_manager.get_config_global_config().general.general.pypath
         };
 
@@ -250,16 +250,16 @@ export class Project_manager {
         const intro_error = "------> ";
 
         this.global_logger.info('Checking dependencies...', true);
-        
+
         // Check python
         const python_result = await teroshdl2.process.python.get_python_path(options);
-        if (python_result.successful === false){
+        if (python_result.successful === false) {
             const doc_msg_link = "https://terostechnology.github.io/terosHDLdoc/docs/getting_started/installation#2-python3";
             const doc_msg = this.get_doc_msg(doc_msg_link);
 
             this.global_logger.error(`${intro_error}Python not found. If you are using system path try setting the complete Python path. ${doc_msg}`);
         }
-        else{
+        else {
             this.global_logger.info(`${intro_info} Python found: ${python_result.python_path}`);
             this.global_logger.info(`${intro_info} Python found in path: ${python_result.python_complete_path}`);
 
@@ -268,22 +268,22 @@ export class Project_manager {
 
             for (const package_name of package_list) {
                 let optional_msg = "";
-                                
+
                 const package_result = await teroshdl2.process.python.check_python_package(python_result.python_path,
                     package_name);
-                if (!package_result){
+                if (!package_result) {
                     const doc_msg_link = "https://terostechnology.github.io/terosHDLdoc/docs/getting_started/installation#3-python3-package-dependencies";
                     const doc_msg = this.get_doc_msg(doc_msg_link);
 
-                    if (package_list_optional.includes(package_name)){
+                    if (package_list_optional.includes(package_name)) {
                         this.global_logger.warn(`${intro_warning} ${package_name} (optional installation) not found. ${doc_msg}`);
                     }
-                    else{
+                    else {
                         this.global_logger.error(`${intro_error} ${package_name} ${optional_msg} not found. ${doc_msg}`);
 
                     }
                 }
-                else{
+                else {
                     this.global_logger.info(`${intro_info} ${package_name} found ${optional_msg}`);
                 }
             }
@@ -292,20 +292,20 @@ export class Project_manager {
         // Check make
         const make_binary_dir = this.project_manager.get_config_global_config().general.general.makepath;
         let make_binary_path = ("make");
-        if (make_binary_dir !== ""){
+        if (make_binary_dir !== "") {
             make_binary_path = path_lib.join(make_binary_dir, make_binary_path);
         }
 
         const proc = new teroshdl2.process.process.Process();
         const make_result = await proc.exec_wait(`${make_binary_path} --version`);
-        if (!make_result.successful){
+        if (!make_result.successful) {
             const doc_msg_link = "https://terostechnology.github.io/terosHDLdoc/docs/getting_started/installation#4-make";
             const doc_msg = this.get_doc_msg(doc_msg_link);
             this.global_logger.error(`${intro_error}Make not found in path: ${make_binary_path}. Check that the path is correct. ${doc_msg}`);
             this.global_logger.error(make_result.stderr);
             this.global_logger.error(make_result.stdout);
         }
-        else{
+        else {
             this.global_logger.info(`${intro_info} Make found in path: ${make_binary_path}.`);
         }
     }

--- a/packages/teroshdl/src/features/tree_views/runs/element.ts
+++ b/packages/teroshdl/src/features/tree_views/runs/element.ts
@@ -124,22 +124,20 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     }
 
     async refresh(): Promise<void> {
-        const selected_project = this.project_manager.get_select_project();
-        if (selected_project.successful === false) {
+        try {
+            const selected_project = this.project_manager.get_selected_project();
+            const config = this.project_manager.get_config_global_config();
+
+            const runs_list = await selected_project.get_test_list(config);
+            const runs_view: Run[] = [];
+            runs_list.forEach(run => {
+                runs_view.push(new Run(run.suite_name, run.name, run.filename, run.location));
+            });
+
+            this.data = runs_view;
+        } catch (error) {
             this.data = [];
-            this._onDidChangeTreeData.fire();
-            return;
         }
-        const prj_name = (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result).get_name();
-        const config = this.project_manager.get_config_global_config();
-
-        const runs_list = await this.project_manager.get_test_list(prj_name, config);
-        const runs_view: Run[] = [];
-        runs_list.forEach(run => {
-            runs_view.push(new Run(run.suite_name, run.name, run.filename, run.location));
-        });
-
-        this.data = runs_view;
         this._onDidChangeTreeData.fire();
     }
 

--- a/packages/teroshdl/src/features/tree_views/runs/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/runs/manager.ts
@@ -22,22 +22,22 @@ import * as element from "./element";
 import { t_Multi_project_manager } from '../../../type_declaration';
 import * as events from "events";
 import * as teroshdl2 from 'teroshdl2';
-import {Run_output_manager} from "../run_output";
-import {Logger} from "../../../logger";
+import { Run_output_manager } from "../run_output";
+import { Logger } from "../../../logger";
 import * as tree_kill from 'tree-kill';
 
 export class Runs_manager {
-    private tree : element.ProjectProvider;
-    private project_manager : t_Multi_project_manager;
-    private run_output_manager : Run_output_manager;
-    private logger : Logger;
-    private emitter : events.EventEmitter;
-    private last_run : any;
+    private tree: element.ProjectProvider;
+    private project_manager: t_Multi_project_manager;
+    private run_output_manager: Run_output_manager;
+    private logger: Logger;
+    private emitter: events.EventEmitter;
+    private last_run: any;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter : events.EventEmitter,
+    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter: events.EventEmitter,
         run_output_manager: Run_output_manager, logger: Logger) {
 
         this.set_commands();
@@ -47,12 +47,12 @@ export class Runs_manager {
         this.project_manager = manager;
         this.tree = new element.ProjectProvider(manager, run_output_manager);
         this.emitter = emitter;
-        
-        context.subscriptions.push(vscode.window.registerTreeDataProvider(element.ProjectProvider.getViewID(), 
+
+        context.subscriptions.push(vscode.window.registerTreeDataProvider(element.ProjectProvider.getViewID(),
             this.tree as element.BaseTreeDataProvider<element.Run>));
     }
 
-    set_commands(){
+    set_commands() {
         vscode.commands.registerCommand("teroshdl.view.runs.run_all", () => this.run(undefined));
         vscode.commands.registerCommand("teroshdl.view.runs.stop", () => this.stop(undefined));
         vscode.commands.registerCommand("teroshdl.view.runs.run", (item) => this.run(item));
@@ -75,22 +75,22 @@ export class Runs_manager {
             const pid = this.last_run.pid;
             tree_kill(pid, 'SIGTERM', (err) => {
                 if (err) {
-                  console.error(err);
+                    console.error(err);
                 } else {
                 }
-              });
+            });
         } catch (error) {
             console.log(error);
         }
     }
 
-    async run(item: element.Run | undefined){
+    async run(item: element.Run | undefined) {
         vscode.window.withProgress({
             location: vscode.ProgressLocation.Window,
             cancellable: false,
             title: 'TerosHDL: Tool running'
         }, async (progress) => {
-        
+
             // Status bar to 0
             progress.report({ increment: 0 });
 
@@ -141,13 +141,13 @@ export class Runs_manager {
         });
     }
 
-    refresh(result: teroshdl2.project_manager.tool_common.t_test_result[]){
+    refresh(result: teroshdl2.project_manager.tool_common.t_test_result[]) {
         this.run_output_manager.set_results(result);
         this.refresh_tree();
         this.emitter.emit('refresh_output');
     }
 
-    refresh_tree(){
+    refresh_tree() {
         this.tree.refresh();
     }
 }

--- a/packages/teroshdl/src/features/tree_views/source/element.ts
+++ b/packages/teroshdl/src/features/tree_views/source/element.ts
@@ -36,8 +36,8 @@ enum SOURCE_TREE_ELEMENT {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 export class Source_tree_element extends vscode.TreeItem {
     public children: any[] | undefined;
-    private logical_name : string = "";
-    private name : string = "";
+    private logical_name: string = "";
+    private name: string = "";
 
     constructor(element_type: SOURCE_TREE_ELEMENT, name: string, is_manual: boolean, select_check: boolean, logical_name: string, children?: any[]) {
         super(
@@ -56,17 +56,17 @@ export class Source_tree_element extends vscode.TreeItem {
             this.iconPath = get_icon("library");
         }
         else {
-            if (select_check === true){
+            if (select_check === true) {
                 this.label = `${path_lib.basename(name)} (current)`;
             }
-            else{
+            else {
                 this.label = path_lib.basename(name);
             }
 
-            if (is_manual === true){
+            if (is_manual === true) {
                 this.label = `${this.label} (M)`;
             }
-            else{
+            else {
                 this.label = `${this.label} (A)`;
             }
 
@@ -85,10 +85,10 @@ export class Source_tree_element extends vscode.TreeItem {
         }
     }
 
-    get_name() : string{
+    get_name(): string {
         return this.name;
     }
-    get_logical_name() : string{
+    get_logical_name(): string {
         return this.logical_name;
     }
 }

--- a/packages/teroshdl/src/features/tree_views/source/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/source/manager.ts
@@ -21,9 +21,7 @@ import * as vscode from "vscode";
 import * as element from "./element";
 import * as utils from "../utils";
 import { t_Multi_project_manager } from '../../../type_declaration';
-import * as teroshdl2 from 'teroshdl2';
 import * as events from "events";
-import * as file_utils from "teroshdl2/out/utils/file_utils";
 
 export class Source_manager {
     private tree: element.ProjectProvider;
@@ -56,124 +54,114 @@ export class Source_manager {
     // Project
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     async save_project() {
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined) {
-            return;
-        }
-        const output_path = await utils.get_save_dialog("Save project", "Save", []);
-        if (output_path !== ""){
-            const prj = this.project_manager.get_project_by_name(prj_name);
-            const prj_edam = prj?.save_edam_yaml(output_path);
-            // file_utils.save_file_sync()
-            // console.log("")
+        try {
+            const prj = this.project_manager.get_selected_project();
+            const output_path = await utils.get_save_dialog("Save project", "Save", []);
+            if (output_path !== "") {
+                prj.save_edam_yaml(output_path);
+            }
+        } catch (error) {
+
         }
     }
 
     async add() {
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined) {
-            return;
-        }
+        try {
+            const prj = this.project_manager.get_selected_project();
+            const element_types = ["Source", "Library"];
+            const picker_value = await utils.get_picker_value(element_types, "Add source/library:");
 
-        const element_types = ["Source", "Library"];
-        const picker_value = await utils.get_picker_value(element_types, "Add source/library:");
-
-        // Add source
-        if (picker_value === element_types[0]) {
-            // const element_types = ["Browser", "Load from CSV", "Load from VUnit run.py", "Load from Vivado .xpr"];
-            const element_types = [
-                "Browser", 
-                "Load from CSV", 
-                "Load from VUnit run.py",
-                "Add all HDL files from a directory and subdirectories",
-                "Add all files from a directory",
-                "Load from Intel® Quartus® Prime project"
-            ];
-            const picker_value = await utils.get_picker_value(element_types, "Add from:");
-
-            // Add from browser
+            // Add source
             if (picker_value === element_types[0]) {
-                await utils.add_sources_from_open_dialog(this.project_manager, prj_name, "");
-            }
-            // Add from CSV
-            else if (picker_value === element_types[1]) {
-                const csv_path = await utils.get_from_open_dialog("Add from CSV", false, true, false, 
-                    "Select CSV file", {'CSV file (*.csv, *.CSV)': ['csv', 'CSV']});
-                if (csv_path.length !== 0) {
-                    this.project_manager.add_file_from_csv(prj_name, csv_path[0], true);
+                // const element_types = ["Browser", "Load from CSV", "Load from VUnit run.py", "Load from Vivado .xpr"];
+                const element_types = [
+                    "Browser",
+                    "Load from CSV",
+                    "Load from VUnit run.py",
+                    "Add all HDL files from a directory and subdirectories",
+                    "Add all files from a directory",
+                    "Load from Intel® Quartus® Prime project"
+                ];
+                const picker_value = await utils.get_picker_value(element_types, "Add from:");
+                // Add from browser
+                if (picker_value === element_types[0]) {
+                    await utils.add_sources_from_open_dialog(prj, "");
+                }
+                // Add from CSV
+                else if (picker_value === element_types[1]) {
+                    const csv_path = await utils.get_from_open_dialog("Add from CSV", false, true, false,
+                        "Select CSV file", { 'CSV file (*.csv, *.CSV)': ['csv', 'CSV'] });
+                    if (csv_path.length !== 0) {
+                        prj.add_file_from_csv(csv_path[0], true);
+                    }
+                }
+                // Add from VUnit
+                else if (picker_value === element_types[2]) {
+                    await utils.add_sources_from_vunit(prj, this.project_manager.get_config_global_config(), true);
+                }
+                // Add from directory and subirectories
+                else if (picker_value === element_types[3]) {
+                    await utils.add_sources_from_directory_and_subdirectories(prj, true);
+                }
+                // Add from directory and subirectories
+                else if (picker_value === element_types[4]) {
+                    await utils.add_sources_from_directory_and_subdirectories(prj, false);
+                }
+                // Add from Quartus
+                else if (picker_value === element_types[5]) {
+                    await utils.add_sources_from_quartus(prj, this.project_manager.get_config_global_config(), true);
                 }
             }
-            // Add from VUnit
-            else if (picker_value === element_types[2]) {
-                await utils.add_sources_from_vunit(this.project_manager, prj_name, true);
+            // Add library
+            else {
+                const logical_name = await utils.get_from_input_box("Add new library", "Library name");
+                if (logical_name !== undefined) {
+                    prj.add_logical(logical_name);
+                }
             }
-            // Add from directory and subirectories
-            else if (picker_value === element_types[3]) {
-                await utils.add_sources_from_directory_and_subdirectories(this.project_manager, prj_name, true);
-            }
-            // Add from directory and subirectories
-            else if (picker_value === element_types[4]) {
-                await utils.add_sources_from_directory_and_subdirectories(this.project_manager, prj_name, false);
-            }
-            // Add from Quartus
-            else if (picker_value === element_types[5]) {
-                await utils.add_sources_from_quartus(this.project_manager, prj_name, true);
-            }
+            this.refresh();
+        } catch (error) {
+
         }
-        // Add library
-        else {
-            const logical_name = await utils.get_from_input_box("Add new library", "Library name");
-            if (logical_name !== undefined) {
-                this.project_manager.add_logical(prj_name, logical_name);
-            }
-        }
-        this.refresh();
     }
 
     async add_source_to_library(item: element.Source_tree_element) {
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined) {
-            return;
+        try {
+            const prj = this.project_manager.get_selected_project();
+            await utils.add_sources_from_open_dialog(prj, item.get_logical_name());
+            this.refresh();
+        } catch (error) {
+
         }
-        await utils.add_sources_from_open_dialog(this.project_manager, prj_name, item.get_logical_name());
-        this.refresh();
     }
 
     async delete_library(item: element.Source_tree_element) {
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined) {
-            return;
+        try {
+            const prj = this.project_manager.get_selected_project();
+            prj.delete_file_by_logical_name(item.get_logical_name());
+            this.refresh();
+        } catch (error) {
+
         }
-        this.project_manager.delete_file_by_logical_name(prj_name, item.get_logical_name());
-        this.refresh();
     }
 
     async delete_source(item: element.Source_tree_element) {
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined) {
-            return;
+        try {
+            const prj = this.project_manager.get_selected_project();
+            prj.delete_file(item.get_name(), item.get_logical_name());
+            this.refresh();
+        } catch (error) {
+
         }
-        this.project_manager.delete_file(prj_name, item.get_name(), item.get_logical_name());
-        this.refresh();
     }
 
     async select_top(item: element.Source_tree_element) {
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined) {
-            return;
-        }
-        this.project_manager.add_toplevel_path(prj_name, item.get_name());
-        this.refresh();
-    }
+        try {
+            const prj = this.project_manager.get_selected_project();
+            prj.add_toplevel_path(item.get_name());
+            this.refresh();
+        } catch (error) {
 
-    get_selected_project_name(): string | undefined {
-        const selected_prj = this.project_manager.get_select_project();
-        // No project select
-        if (selected_prj.successful === false) {
-            return undefined;
-        }
-        else {
-            return (<teroshdl2.project_manager.project_manager.Project_manager>selected_prj.result).get_name();
         }
     }
 

--- a/packages/teroshdl/src/features/tree_views/source/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/source/manager.ts
@@ -28,12 +28,12 @@ import * as file_utils from "teroshdl2/out/utils/file_utils";
 export class Source_manager {
     private tree: element.ProjectProvider;
     private project_manager: t_Multi_project_manager;
-    private emitter : events.EventEmitter;
+    private emitter: events.EventEmitter;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter : events.EventEmitter) {
+    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter: events.EventEmitter) {
         this.set_commands();
 
         this.emitter = emitter;
@@ -177,11 +177,11 @@ export class Source_manager {
         }
     }
 
-    refresh(){
+    refresh() {
         this.emitter.emit('refresh');
     }
 
-    refresh_tree(){
+    refresh_tree() {
         this.tree.refresh();
     }
 }

--- a/packages/teroshdl/src/features/tree_views/utils.ts
+++ b/packages/teroshdl/src/features/tree_views/utils.ts
@@ -20,7 +20,6 @@
 import * as path_lib from "path";
 import * as vscode from "vscode";
 import * as teroshdl2 from 'teroshdl2';
-import { t_Multi_project_manager } from '../../type_declaration';
 import * as utils from "./utils";
 
 const BASE_PATH_ICON = path_lib.join(__filename, "..", "..", "..", "..", "resources", "icon");
@@ -87,7 +86,7 @@ export async function get_from_input_box(prompt: string, place_holder: string) {
     return value;
 }
 
-export async function add_sources_from_open_dialog(project_manager: t_Multi_project_manager, prj_name: string, logical_name: string) {
+export async function add_sources_from_open_dialog(prj: teroshdl2.project_manager.project_manager.Project_manager, logical_name: string) {
     const source_path_list = await get_from_open_dialog("Add sources", false, true, true,
         "Select source file", { 'All files (*.*)': ['*'] });
     source_path_list.forEach(source_path => {
@@ -100,12 +99,11 @@ export async function add_sources_from_open_dialog(project_manager: t_Multi_proj
             file_type: teroshdl2.utils.file.get_language_from_filepath(source_path),
             file_version: teroshdl2.utils.file.get_default_version_for_filepath(source_path)
         };
-        project_manager.add_file(prj_name, f);
+        prj.add_file(f);
     });
 }
 
-export async function add_sources_from_directory_and_subdirectories(project_manager: t_Multi_project_manager,
-    prj_name: string, allow_subdirectories: boolean) {
+export async function add_sources_from_directory_and_subdirectories(prj: teroshdl2.project_manager.project_manager.Project_manager, allow_subdirectories: boolean) {
 
     const directory_list = await get_from_open_dialog("Select directory", true, false, true,
         "Select", []);
@@ -134,31 +132,31 @@ export async function add_sources_from_directory_and_subdirectories(project_mana
                 file_type: teroshdl2.utils.file.get_language_from_filepath(file_inst),
                 file_version: teroshdl2.utils.file.get_default_version_for_filepath(file_inst)
             };
-            project_manager.add_file(prj_name, f);
+            prj.add_file(f);
         });
     });
 }
 
-export async function add_sources_from_vunit(project_manager: t_Multi_project_manager, prj_name: string, is_manual: boolean) {
+export async function add_sources_from_vunit(prj: teroshdl2.project_manager.project_manager.Project_manager, config: teroshdl2.config.config_declaration.e_config, is_manual: boolean) {
     const path_list = await utils.get_from_open_dialog("Select run.py", false, true, true,
         "Select VUnit run.py files", { 'Python files (*.py)': ['py'] });
-    for (const path of path_list) {
-        await project_manager.add_file_from_vunit(prj_name, project_manager.get_config_global_config(), path, is_manual);
-    }
+    path_list.forEach(async path => {
+        await prj.add_file_from_vunit(config, path, is_manual);
+    });
 }
 
-export async function add_sources_from_vivado(project_manager: t_Multi_project_manager, prj_name: string, is_manual: boolean) {
-    const path_list = await utils.get_from_open_dialog("Select Vivado project", false, true, false,
+export async function add_sources_from_vivado(prj: teroshdl2.project_manager.project_manager.Project_manager, config: teroshdl2.config.config_declaration.e_config, is_manual: boolean) {
+    const path_list = await utils.get_from_open_dialog("Select Vivado project", false, true, true,
         "Select Vivado project", { 'Vivado project (*.xpr)': ['xpr'] });
-    for (const path of path_list) {
-        await project_manager.add_file_from_vivado(prj_name, project_manager.get_config_global_config(), path, is_manual);
-    }
+    path_list.forEach(async path => {
+        await prj.add_file_from_vivado(config, path, is_manual);
+    });
 }
 
-export async function add_sources_from_quartus(project_manager: t_Multi_project_manager, prj_name: string, is_manual: boolean) {
+export async function add_sources_from_quartus(prj: teroshdl2.project_manager.project_manager.Project_manager, config: teroshdl2.config.config_declaration.e_config, is_manual: boolean) {
     const path_list = await utils.get_from_open_dialog("Select Quartus project", false, true, false,
         "Select Quartus project", { 'Quartus project (*.qsf)': ['qsf'] });
     for (const path of path_list) {
-        await project_manager.add_file_from_quartus(prj_name, project_manager.get_config_global_config(), path, is_manual);
+        await prj.add_file_from_quartus(config, path, is_manual);
     }
 }

--- a/packages/teroshdl/src/features/tree_views/watchers/element.ts
+++ b/packages/teroshdl/src/features/tree_views/watchers/element.ts
@@ -20,7 +20,6 @@
 import { Multi_project_manager } from "teroshdl2/out/project_manager/multi_project_manager";
 import * as vscode from "vscode";
 import { get_icon } from "../utils";
-import * as teroshdl2 from "teroshdl2";
 import * as path_lib from "path";
 
 export const VIEW_ID = "teroshdl-view-watcher";
@@ -98,21 +97,18 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     }
 
     refresh(): void {
-        const watcher_view : Watcher[] = [];
-        const selected_project = this.project_manager.get_select_project();
-        if (selected_project.successful === false) {
+        const watcher_view: Watcher[] = [];
+        try {
+            const prj_definition = this.project_manager.get_selected_project().get_project_definition();
+            const watcher_list = prj_definition.watcher_manager.get();
+
+            watcher_list.forEach(watcher_inst => {
+                watcher_view.push(new Watcher(watcher_inst.path));
+            });
+            this.data = watcher_view;
+        } catch (error) {
             this.data = [];
-            this._onDidChangeTreeData.fire();
-            return;
         }
-
-        const prj_definition = (<teroshdl2.project_manager.project_manager.Project_manager>selected_project.result).get_project_definition();
-        const watcher_list = prj_definition.watcher_manager.get();
-
-        watcher_list.forEach(watcher_inst => {
-            watcher_view.push(new Watcher(watcher_inst.path));
-        });
-        this.data = watcher_view;
         this._onDidChangeTreeData.fire();
     }
 }

--- a/packages/teroshdl/src/features/tree_views/watchers/element.ts
+++ b/packages/teroshdl/src/features/tree_views/watchers/element.ts
@@ -19,7 +19,7 @@
 
 import { Multi_project_manager } from "teroshdl2/out/project_manager/multi_project_manager";
 import * as vscode from "vscode";
-import {get_icon} from "../utils";
+import { get_icon } from "../utils";
 import * as teroshdl2 from "teroshdl2";
 import * as path_lib from "path";
 
@@ -32,7 +32,7 @@ export class Watcher extends vscode.TreeItem {
     public children: any[] | undefined;
     public iconPath = get_icon("search");
     public contextValue = "watcher";
-    private name : string;
+    private name: string;
 
     constructor(name: string, children?: any[]) {
         super(
@@ -52,7 +52,7 @@ export class Watcher extends vscode.TreeItem {
         };
     }
 
-    public get_name() : string{
+    public get_name(): string {
         return this.name;
     }
 }
@@ -70,14 +70,14 @@ export abstract class BaseTreeDataProvider<T> implements vscode.TreeDataProvider
 }
 
 export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
-    
+
     private _onDidChangeTreeData: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     readonly onDidChangeTreeData: vscode.Event<void> = this._onDidChangeTreeData.event;
 
     data: TreeItem[] = [];
-    private project_manager : Multi_project_manager;
+    private project_manager: Multi_project_manager;
 
-    constructor(project_manager : Multi_project_manager) {
+    constructor(project_manager: Multi_project_manager) {
         super();
         this.project_manager = project_manager;
     }

--- a/packages/teroshdl/src/features/tree_views/watchers/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/watchers/manager.ts
@@ -26,24 +26,24 @@ import * as utils from "../utils";
 import * as teroshdl2 from "teroshdl2";
 
 export class Watcher_manager {
-    private tree : element.ProjectProvider;
-    private project_manager : t_Multi_project_manager;
-    private emitter : events.EventEmitter;
+    private tree: element.ProjectProvider;
+    private project_manager: t_Multi_project_manager;
+    private emitter: events.EventEmitter;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter : events.EventEmitter) {
+    constructor(context: vscode.ExtensionContext, manager: t_Multi_project_manager, emitter: events.EventEmitter) {
         this.set_commands();
 
         this.emitter = emitter;
         this.project_manager = manager;
         this.tree = new element.ProjectProvider(manager);
-        
+
         context.subscriptions.push(vscode.window.registerTreeDataProvider(element.ProjectProvider.getViewID(), this.tree as element.BaseTreeDataProvider<element.Watcher>));
     }
 
-    set_commands(){
+    set_commands() {
         vscode.commands.registerCommand("teroshdl.view.watcher.add", (item) => this.add(item));
         vscode.commands.registerCommand("teroshdl.view.watcher.delete", (item) => this.delete(item));
     }
@@ -102,11 +102,11 @@ export class Watcher_manager {
         this.refresh();
     }
 
-    refresh(){
+    refresh() {
         this.emitter.emit('refresh');
     }
 
-    refresh_tree(){
+    refresh_tree() {
         this.tree.refresh();
     }
 }

--- a/packages/teroshdl/src/features/tree_views/watchers/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/watchers/manager.ts
@@ -51,55 +51,47 @@ export class Watcher_manager {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Project
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    async add(item: element.Watcher){
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined){
-            return;
-        }
+    async add(item: element.Watcher) {
+        try {
 
-        // const element_types = ["VUnit", "CSV", "Vivado project"];
-        const element_types = ["VUnit", "CSV"];
-        const picker_value = await utils.get_picker_value(element_types, "Choose file watcher type");
-        let watcher_type = teroshdl2.project_manager.common.e_watcher_type.CSV;
-        if (picker_value === element_types[0]){
-            watcher_type = teroshdl2.project_manager.common.e_watcher_type.VUNIT;
-        }
-        else if(picker_value === element_types[1]){
-            watcher_type = teroshdl2.project_manager.common.e_watcher_type.CSV;
-        }
-        // else if(picker_value === element_types[2]){
-        //     watcher_type = teroshdl2.project_manager.common.e_watcher_type.VIVADO;
-        // }
-        else{
-            return;
-        }
-        const path_list = await utils.get_from_open_dialog("Add watcher", false, true, true, 
-            "Select watcher files", {'File (*.*)': ['*']});
-        
-        path_list.forEach(path_inst => {
-            this.project_manager.add_file_to_watcher(prj_name, {path: path_inst, watcher_type: watcher_type});
-        });
-        this.refresh();
-    }
+            const prj = this.project_manager.get_selected_project();
 
-    get_selected_project_name(): string | undefined {
-        const selected_prj = this.project_manager.get_select_project();
-        // No project select
-        if (selected_prj.successful === false) {
-            return undefined;
-        }
-        else {
-            return (<teroshdl2.project_manager.project_manager.Project_manager>selected_prj.result).get_name();
+            // const element_types = ["VUnit", "CSV", "Vivado project"];
+            const element_types = ["VUnit", "CSV"];
+            const picker_value = await utils.get_picker_value(element_types, "Choose file watcher type");
+            let watcher_type = teroshdl2.project_manager.common.e_watcher_type.CSV;
+            if (picker_value === element_types[0]) {
+                watcher_type = teroshdl2.project_manager.common.e_watcher_type.VUNIT;
+            }
+            else if (picker_value === element_types[1]) {
+                watcher_type = teroshdl2.project_manager.common.e_watcher_type.CSV;
+            }
+            // else if(picker_value === element_types[2]){
+            //     watcher_type = teroshdl2.project_manager.common.e_watcher_type.VIVADO;
+            // }
+            else {
+                return;
+            }
+            const path_list = await utils.get_from_open_dialog("Add watcher", false, true, true,
+                "Select watcher files", { 'File (*.*)': ['*'] });
+
+            path_list.forEach(path_inst => {
+                prj.add_file_to_watcher({ path: path_inst, watcher_type: watcher_type });
+            });
+            this.refresh();
+        } catch (error) {
+
         }
     }
 
-    delete(item: element.Watcher){
-        const prj_name = this.get_selected_project_name();
-        if (prj_name === undefined){
-            return;
+    delete(item: element.Watcher) {
+        try {
+            const prj = this.project_manager.get_selected_project();
+            prj.delete_file_in_watcher(item.get_name());
+            this.refresh();
+        } catch (error) {
+
         }
-        this.project_manager.delete_file_in_watcher(prj_name, item.get_name());
-        this.refresh();
     }
 
     refresh() {

--- a/packages/teroshdl/src/teroshdl.ts
+++ b/packages/teroshdl/src/teroshdl.ts
@@ -56,7 +56,8 @@ export class Teroshdl {
         const file_prj_path = path_lib.join(homedir, PRJ_FILENAME);
 
         this.manager = new teroshdl2.project_manager.multi_project_manager.Multi_project_manager(
-            "", file_config_path, file_prj_path, this.emitter);
+            file_config_path, file_prj_path, this.emitter);
+        this.manager.load();
         this.context = context;
         this.global_logger = global_logger;
     }


### PR DESCRIPTION
# Multi Project Manager (MPM) Analysis

## Inputs (API to teroshdl)
### Projects management
- constructor: load_from_sync_file it's only called internally by the constructor. 
- create_project: initialize the project, could `initialize_project` be a cleaner name?
- create_project_from_json_edam
- create_project_from_yaml_edam: should this be here? One input (json) and the caller is in charge of converting from yaml to json, because yaml (or others) are options supported by teroshdl and not by colibri. I'd say is even better to provide `load_edam_project` and teroshdl is in charge of converting from json/yaml/whatever to dict/structure
- rename_project
- delete_project
- select_project_current

### A lot of project_manager (PM) wrappers
- add_file_to_watcher
- delete_file_in_watcher
- add_toplevel_path
- delete_toplevel_path
- add_logical
- add_file
- add_file_from_csv
- run
- clean
- get test list
- check_if_file_in_project
...

There are two possible approaches:
- MPM returns ProjectManager instance(s) and teroshdl is in charge of calling these methods from PM instances. We remove them from here. Shouldn't be tested in MPM scope, but in PM scope.
- PMs are internal classes to MPM, and never directly used by teroshdl. teroshdl uses those wrapper methods, and get_projects (and similar functions) returns a dictionary with the info to represent, but never an instance with callable setter/action functions. If there's extra logic in the MPM wrappers (save call), this makes sense.

### Configuration
- set_global_config
- set_global_config_from_json: I'd keep a `set_global_config` using a dict/structure. The frontend can provide json/whatever doing the conversion from json/format to dict/structure. 
- set_config

Maybe rename global_config to default_config ?

Configuration approach should be similar to PM wrappers. 

## Outputs

### API to teroshdl
#### Projects management
- get_projects: it shouldn't return real PM instances
- get_project_by_name: does it make sense if we have wrappers? I'm only seeing one usage: saving the project. Could it be a standalone input function `save_edam_project`. Also, does it also make sense to save just one project change? should we just call "global" save?
- get_select_project: just return name/id

#### Configuration
- get_config_manager. I don't think config manager should be accessible from outside, we can move to wrapper approach if required,
- get_global_config
- get_config. Config object should be an object without setters/actions

 ### Database / json file
 - file_utils.save_file_sync: why "sync file" and not just a regular file?
 - file_utils.read_file_sync

save is called from outside? does it make sense if we call it internally every time there's a change, and all changes are only doable trough the class?
