### PR TITLE
Project file fix when running on windows caused by double back slash.…

### DIFF
--- a/packages/colibri/src/project_manager/list_manager/file.ts
+++ b/packages/colibri/src/project_manager/list_manager/file.ts
@@ -95,6 +95,8 @@ export class File_manager extends Manager<t_file, undefined, string, string> {
             const new_files = this.files.map(obj => ({ ...obj }));
             for (let i = 0; i < new_files.length; i++) {
                 new_files[i].name = file_utils.get_relative_path(new_files[i].name, reference_file_path);
+                // Replaces double back slash generated when running on Windows
+                new_files[i].name = new_files[i].name.replace("\\", '/');
             }
             return new_files;
         }


### PR DESCRIPTION
… When double back slash is saved into a file the first one is working as a scape char resulting in one back slash in the relative path unabling to load the project again. This is solved by replacing double back slash with forward slash.
Example of yaml project file saved in Windows:
Before:
```
files: 
  - name: "src\example1.vhd"
```

After: 
```
files: 
  - name: "src/example1.vhd"
```