### PR TITLE
fix licence comment symbol bug 

### DIFF
--- a/packages/colibri/src/template/manager.ts
+++ b/packages/colibri/src/template/manager.ts
@@ -27,26 +27,29 @@ import { get_template } from "./helpers/template";
 /** Template */
 export class Template_manager {
     private language: LANGUAGE = LANGUAGE.VHDL;
-    private comment_symbol = "//";
 
     /**
      * @param  {LANGUAGE} language Language name
      */
     constructor(language: LANGUAGE) {
-        if (language === LANGUAGE.VHDL) {
-            this.comment_symbol = '//';
-        }
-        else {
-            this.comment_symbol = '--';
-        }
         this.language = language;
     }
 
     /**
      * Get the text header from a file path
      * @param  {string} header_file_path File path with the header
+     * @param  {LANGUAGE} target_lang Target language 
      */
-    private get_header(header_file_path: string) {
+    private get_header(header_file_path: string, target_lang: LANGUAGE) {
+        let comment_symbol = "";
+
+        if(target_lang === LANGUAGE.VHDL){
+            comment_symbol = '--';
+        }
+        else{
+            comment_symbol = '//';
+        }
+
         if (header_file_path === '') {
             return '';
         }
@@ -57,7 +60,7 @@ export class Template_manager {
             let header = '';
             for (let i = 0; i < lines.length; i++) {
                 const element = lines[i];
-                header += `${this.comment_symbol}  ${element}\n`;
+                header += `${comment_symbol}  ${element}\n`;
             }
             return header + '\n';
         }
@@ -100,12 +103,21 @@ export class Template_manager {
      * @param  {string} code HDL code
      * @param  {common.TEMPLATE_NAME} template_type Template type
      * @param  {common.t_options} options Template options
+     * @param  {string} options Template options
+     * @param  {LANGUAGE} target_lang Target language 
      */
-    async generate(code: string, template_type: string, options: t_template_options) {
+    async generate(code: string, template_type: string, options: t_template_options, target_lang?: LANGUAGE) {
+        let target_language = LANGUAGE.VHDL;
         let norm_language = this.language;
         if (this.language === LANGUAGE.SYSTEMVERILOG) {
             norm_language = LANGUAGE.VERILOG;
         }
+
+        if(typeof target_lang === 'undefined'){
+            target_language = norm_language;
+        }else{
+            target_language = target_lang;
+        }   
 
         let template = '';
         const code_tree = await this.parse(code);
@@ -113,7 +125,7 @@ export class Template_manager {
             return template;
         }
         // Get header
-        const header = this.get_header(options.header_file_path);
+        const header = this.get_header(options.header_file_path, target_language);
         // Indent
         const indent = this.get_indent(options.indent_char);
         // Template parent

--- a/packages/colibri/tests/template/expected_with_generic/vhdl_testbench_normal.vhdl
+++ b/packages/colibri/tests/template/expected_with_generic/vhdl_testbench_normal.vhdl
@@ -1,13 +1,13 @@
-//  The licenses for most software and other practical works are designed
-//  to take away your freedom to share and change the works.  By contrast,
-//  the GNU General Public License is intended to guarantee your freedom to
-//  share and change all versions of a program--to make sure it remains free
-//  software for all its users.  We, the Free Software Foundation, use the
-//  GNU General Public License for most of our software; it applies also to
-//  any other work released this way by its authors.  You can apply it to
-//  your programs, too.
-//  
-//  
+--  The licenses for most software and other practical works are designed
+--  to take away your freedom to share and change the works.  By contrast,
+--  the GNU General Public License is intended to guarantee your freedom to
+--  share and change all versions of a program--to make sure it remains free
+--  software for all its users.  We, the Free Software Foundation, use the
+--  GNU General Public License for most of our software; it applies also to
+--  any other work released this way by its authors.  You can apply it to
+--  your programs, too.
+--  
+--  
 
 
 

--- a/packages/colibri/tests/template/expected_with_generic/vhdl_testbench_vunit.vhdl
+++ b/packages/colibri/tests/template/expected_with_generic/vhdl_testbench_vunit.vhdl
@@ -1,13 +1,13 @@
-//  The licenses for most software and other practical works are designed
-//  to take away your freedom to share and change the works.  By contrast,
-//  the GNU General Public License is intended to guarantee your freedom to
-//  share and change all versions of a program--to make sure it remains free
-//  software for all its users.  We, the Free Software Foundation, use the
-//  GNU General Public License for most of our software; it applies also to
-//  any other work released this way by its authors.  You can apply it to
-//  your programs, too.
-//  
-//  
+--  The licenses for most software and other practical works are designed
+--  to take away your freedom to share and change the works.  By contrast,
+--  the GNU General Public License is intended to guarantee your freedom to
+--  share and change all versions of a program--to make sure it remains free
+--  software for all its users.  We, the Free Software Foundation, use the
+--  GNU General Public License for most of our software; it applies also to
+--  any other work released this way by its authors.  You can apply it to
+--  your programs, too.
+--  
+--  
 
 
 

--- a/packages/colibri/tests/template/expected_without_generic/vhdl_testbench_normal.vhdl
+++ b/packages/colibri/tests/template/expected_without_generic/vhdl_testbench_normal.vhdl
@@ -1,13 +1,13 @@
-//  The licenses for most software and other practical works are designed
-//  to take away your freedom to share and change the works.  By contrast,
-//  the GNU General Public License is intended to guarantee your freedom to
-//  share and change all versions of a program--to make sure it remains free
-//  software for all its users.  We, the Free Software Foundation, use the
-//  GNU General Public License for most of our software; it applies also to
-//  any other work released this way by its authors.  You can apply it to
-//  your programs, too.
-//  
-//  
+--  The licenses for most software and other practical works are designed
+--  to take away your freedom to share and change the works.  By contrast,
+--  the GNU General Public License is intended to guarantee your freedom to
+--  share and change all versions of a program--to make sure it remains free
+--  software for all its users.  We, the Free Software Foundation, use the
+--  GNU General Public License for most of our software; it applies also to
+--  any other work released this way by its authors.  You can apply it to
+--  your programs, too.
+--  
+--  
 
 
 

--- a/packages/colibri/tests/template/expected_without_generic/vhdl_testbench_vunit.vhdl
+++ b/packages/colibri/tests/template/expected_without_generic/vhdl_testbench_vunit.vhdl
@@ -1,13 +1,13 @@
-//  The licenses for most software and other practical works are designed
-//  to take away your freedom to share and change the works.  By contrast,
-//  the GNU General Public License is intended to guarantee your freedom to
-//  share and change all versions of a program--to make sure it remains free
-//  software for all its users.  We, the Free Software Foundation, use the
-//  GNU General Public License for most of our software; it applies also to
-//  any other work released this way by its authors.  You can apply it to
-//  your programs, too.
-//  
-//  
+--  The licenses for most software and other practical works are designed
+--  to take away your freedom to share and change the works.  By contrast,
+--  the GNU General Public License is intended to guarantee your freedom to
+--  share and change all versions of a program--to make sure it remains free
+--  software for all its users.  We, the Free Software Foundation, use the
+--  GNU General Public License for most of our software; it applies also to
+--  any other work released this way by its authors.  You can apply it to
+--  your programs, too.
+--  
+--  
 
 
 

--- a/packages/colibri/tests/template/template.spec.ts
+++ b/packages/colibri/tests/template/template.spec.ts
@@ -151,9 +151,22 @@ TEST_TYPE_LIST.forEach(TEST_TYPE => {
                         extension = "vhdl";
                     }
 
+                    let lang_template = LANGUAGE.NONE;
+                    const template_def = common.get_template_definition(language);
+                    for (let i = 0; i < template_def.lang_list.length; i++) {
+                        if (template_type.id === template_def.id_list[i]) {
+                            lang_template = template_def.lang_list[i];
+                            break;
+                        }
+                    }
+
                     const template_manager = await generate_template_manager(language);
                     const inst_hdl = code_hdl[counter];
-                    const template = await template_manager.generate(inst_hdl, template_type.id, config);
+                    const template = await template_manager.generate(inst_hdl, 
+                                                                    template_type.id, 
+                                                                    config, 
+                                                                    lang_template);
+
                     const output_path = paht_lib.join(C_OUTPUT_BASE_PATH,
                         `${extension}_${template_type.id}.${extension}`);
                     fs.writeFileSync(output_path, template);

--- a/packages/teroshdl/src/features/templates.ts
+++ b/packages/teroshdl/src/features/templates.ts
@@ -70,7 +70,7 @@ export class Template_manager {
         const template_manager = new teroshdl2.template.manager.Template_manager(lang);
 
         const options = this.get_config();
-        const template = await template_manager.generate(code, select_id, options);
+        const template = await template_manager.generate(code, select_id, options, lang_template);
 
         //Error
         if (template === undefined || template === '') {


### PR DESCRIPTION
Bugfix: #465 
Fix licence comment symbol bug when generating template for other language different than the source file.