### PR TITLE
fix: Edam Files format is incompatible with TerosHDL's file format

### DIFF
--- a/packages/colibri/src/project_manager/tool/edalize/edalize.ts
+++ b/packages/colibri/src/project_manager/tool/edalize/edalize.ts
@@ -77,7 +77,7 @@ export class Edalize extends Generic_tool_handler {
         const config = prj.config;
 
         // Save EDAM project in JSON file
-        let edam_json = get_edam_json(prj, top_level_list);
+        let edam_json = get_edam_json(prj, top_level_list, undefined, true);
         // Set waveform
         edam_json = this.set_waveform(config, edam_json);
 

--- a/packages/colibri/src/project_manager/utils/utils.ts
+++ b/packages/colibri/src/project_manager/utils/utils.ts
@@ -24,7 +24,7 @@ import * as jsYaml from 'js-yaml';
 const initSqlJs = require('sql.js');
 
 export function get_edam_json(prj: t_project_definition, top_level_list: undefined | string[],
-    refrence_path?: string) {
+    refrence_path?: string, standartized_file_type_notation = false) {
 
     // Set tool options in EDAM format
     const tool_name = prj.config.tools.general.select_tool;
@@ -97,7 +97,7 @@ export function get_edam_json(prj: t_project_definition, top_level_list: undefin
         project_disk_path: prj.project_disk_path,
         project_type: prj.project_type,
         toplevel: top_level,
-        files: edam_files,
+        files: standartized_file_type_notation ? edam_files : files,
         hooks: prj.hook_manager.get(),
         watchers: prj.watcher_manager.get(refrence_path),
         configuration: prj.config,
@@ -108,8 +108,8 @@ export function get_edam_json(prj: t_project_definition, top_level_list: undefin
 }
 
 export function get_edam_yaml(prj: t_project_definition, top_level_list: undefined | string[],
-    reference_path?: string) {
-    const edamJSON = get_edam_json(prj, top_level_list, reference_path);
+    reference_path?: string, standartized_file_type_notation = false) {
+    const edamJSON = get_edam_json(prj, top_level_list, reference_path, standartized_file_type_notation);
     const edamYaml = jsYaml.dump(edamJSON);
     return edamYaml;
 }

--- a/packages/colibri/src/project_manager/utils/utils.ts
+++ b/packages/colibri/src/project_manager/utils/utils.ts
@@ -47,12 +47,57 @@ export function get_edam_json(prj: t_project_definition, top_level_list: undefin
         top_level = top_level_list[0];
     }
 
+    const files = prj.file_manager.get(refrence_path);
+
+    type t_edam_file = {
+        /** File name with (absolute or relative) path */
+        name: string;
+        /** Indicates if this file should be treated as an include file (default false) */
+        is_include_file: boolean;
+        /** When is_include_file is true, the directory containing the file will be 
+         * added to the include path. include_path allows setting an explicit directory to use instead */
+        include_path: string;
+        /** Logical name (e.g. VHDL/SystemVerilog library) of the file */
+        logical_name: string;
+        /** File type */
+        file_type: string;
+    }
+
+    const edam_files = files.map((file) => {
+        const edam_file_type = () => {
+            switch (file.file_type) {
+                case general.LANGUAGE.VHDL:
+                    if (file.file_version === general.VHDL_LANG_VERSION.v2008) {
+                        return `${file.file_type}-${file.file_version}`;
+                    }
+                    break;
+                case general.LANGUAGE.VERILOG:
+                    if (file.file_version === general.VERILOG_LANG_VERSION.v2005) {
+                        return `${file.file_type}-${file.file_version}`;
+                    }
+                    break;
+            }
+
+            return file.file_type.toString();
+        }
+
+        const edam_file: t_edam_file = {
+            name: file.name,
+            include_path: file.include_path,
+            is_include_file: file.is_include_file,
+            logical_name: file.logical_name,
+            file_type: edam_file_type()
+        };
+
+        return edam_file;
+    })
+
     const edam_json = {
         name: prj.name,
         project_disk_path: prj.project_disk_path,
         project_type: prj.project_type,
         toplevel: top_level,
-        files: prj.file_manager.get(refrence_path),
+        files: edam_files,
         hooks: prj.hook_manager.get(),
         watchers: prj.watcher_manager.get(refrence_path),
         configuration: prj.config,


### PR DESCRIPTION
Edam's `File` field [must contain](https://edalize.readthedocs.io/en/latest/edam/api.html#file) the `file_type` in a format like `vhdlSource-2008`.

Latest TerosHDL's project structure changes have a different approach for version storage. It is done by storing a version information in a separate `file_version` field, while `file_type` still used as a file type. For example: `file_type` is `vhdlSource` and `file_version` is `2008`.

```ts
export type t_file = {
    /** File type */
    file_type: LANGUAGE;
    /** File version */
    file_version: VHDL_LANG_VERSION | VERILOG_LANG_VERSION;
}
```

So that change pass the file information structure to Edalize in a wrong format. That is cause of loosing version information.

To fix that, the file type and the file version must be combined back. At least, I guess it must be for `verilogSource-2005` and `vhdlSource-2008`.

However, I'm no sure what version Edam file assumes if `file_type` doesn't contain explicit version. So the fix is discussionable. Also, I didn't check other side effects of project structure change. This changes effectively fix recognition of `vhdlSource-2008` and, maybe, `verilogSource-2005`.