### PR TITLE
Better Naming and  Add Support for Handling Both m4out and m5out SVG Outputs

### DIFF
--- a/packages/colibri/src/config/config_declaration.ts
+++ b/packages/colibri/src/config/config_declaration.ts
@@ -625,7 +625,7 @@ export enum e_tools_general_select_tool {
     xsim = "xsim",
     raptor = "raptor",
     radiant = "radiant",
-    sandpiper = "sandpiper",
+    sandpiper = "sandPiper",
 }
 export enum e_tools_general_execution_mode {
     gui = "gui",
@@ -1803,7 +1803,7 @@ export function get_config_from_json(json_config: any): e_config {
     if ( current_value_72 === "radiant"){
         default_config['tools']['general']['select_tool'] = e_tools_general_select_tool.radiant;
     }
-    if ( current_value_72 === "sandpiper"){
+    if ( current_value_72 === "sandPiper"){
         default_config['tools']['general']['select_tool'] = e_tools_general_select_tool.sandpiper;
     }
             

--- a/packages/colibri/src/config/config_web.ts
+++ b/packages/colibri/src/config/config_web.ts
@@ -1628,7 +1628,7 @@ export const WEB_CONFIG = `
                       <option value='xsim'>XSIM</option>
                       <option value='raptor'>Raptor Design Suite</option>
                       <option value='radiant'>Radiant</option>
-                      <option value='sandpiper'>Sandpiper</option>
+                      <option value='sandpiper'>SandPiper</option>
               </select>
             </div>
           

--- a/packages/colibri/src/config/helpers/configs/tools/general.yml
+++ b/packages/colibri/src/config/helpers/configs/tools/general.yml
@@ -23,7 +23,7 @@ select_tool:
     xsim: "XSIM"
     raptor: "Raptor Design Suite"
     radiant: "Radiant"
-    sandpiper: "Sandpiper"
+    sandpiper: "SandPiper"
 
   value: "ghdl"
 

--- a/packages/colibri/src/config/web_config.html
+++ b/packages/colibri/src/config/web_config.html
@@ -1607,7 +1607,7 @@
                       <option value='xsim'>XSIM</option>
                       <option value='raptor'>Raptor Design Suite</option>
                       <option value='radiant'>Radiant</option>
-                      <option value='sandpiper'>Sandpiper</option>
+                      <option value='sandpiper'>SandPiper</option>
               </select>
             </div>
           

--- a/packages/colibri/src/project_manager/common.ts
+++ b/packages/colibri/src/project_manager/common.ts
@@ -63,7 +63,7 @@ export type t_terminalCommandDefinition = {
 export enum e_project_type {
     GENERIC = "genericProject",
     QUARTUS = "quartusProject",
-    SANDPIPER = "sandpiperProject",
+    SANDPIPER = "TL-VerilogProject",
 }
 
 /** Type of parameter */

--- a/packages/colibri/src/project_manager/tool/sandpiper/taskRunner.ts
+++ b/packages/colibri/src/project_manager/tool/sandpiper/taskRunner.ts
@@ -20,15 +20,15 @@ export function runTask(
   switch (taskType) {
     case e_taskType.SANDPIPER_TLVERILOGTOVERILOG:
       command = "echo";
-      args = ["Sandpiper TL-Verilog to Verilog conversion initiated"];
+      args = ["TL-Verilog to Verilog conversion initiated"];
       break;
     case e_taskType.SANDPIPER_DIAGRAM_TAB:
       command = "echo";
-      args = ["Sandpiper diagram generation initiated"];
+      args = ["Diagram generation initiated"];
       break;
     case e_taskType.SANDPIPER_NAV_TLV_TAB:
       command = "echo";
-      args = ["Sandpiper NavTLV generation initiated"];
+      args = ["NavTLV generation initiated"];
       break;
     default:
       command = "echo";

--- a/packages/colibri/src/project_manager/tool/sandpiper/utils.ts
+++ b/packages/colibri/src/project_manager/tool/sandpiper/utils.ts
@@ -27,7 +27,7 @@ export async function runTLVerilogToVerilogConversion(
       const args = `-i ${currentFileName} -o ${currentFileName.replace(
         ".tlv",
         ".sv"
-      )} --m4out out/m4out ${externSettings.join(" ")} --iArgs`;
+      )} --m5out out/m5out ${externSettings.join(" ")} --iArgs`;
   
       const response = await axios.post(
         SANDPIPER_API_URL,
@@ -135,7 +135,9 @@ export async function runTLVerilogToVerilogConversion(
       }
   
       const data = response.data;
-      const svgOutputKey = `out/${currentFileName.replace('.tlv', '.m4out_graph.svg')}`;
+      const svgOutputKeyM4 = `out/${currentFileName.replace('.tlv', '.m4out_graph.svg')}`;
+      const svgOutputKeyM5 = `out/${currentFileName.replace('.tlv', '.m5out_graph.svg')}`;
+      const svgOutputKey = data[svgOutputKeyM5] ? svgOutputKeyM5 : svgOutputKeyM4;
       if (data[svgOutputKey]) {
         const svgContent = data[svgOutputKey];
         const svgFilePath = path.join(projectPath, `${path.basename(currentFileName, '.tlv')}_diagram.svg`);
@@ -193,7 +195,10 @@ export async function runTLVerilogToVerilogConversion(
       }
   
       const data = response.data;
-      const htmlOutputKey = `out/${currentFileName.replace('.tlv', '.m4out.html')}`;
+      const htmlOutputKeyM4 = `out/${currentFileName.replace('.tlv', '.m4out.html')}`;
+      const htmlOutputKeyM5 = `out/${currentFileName.replace('.tlv', '.m5out.html')}`;
+
+      const htmlOutputKey =  data[htmlOutputKeyM5] ? htmlOutputKeyM5 : htmlOutputKeyM4;
       if (data[htmlOutputKey]) {
         const htmlContent = data[htmlOutputKey];
         emitterProject.emitEventLog(`Generated NavTLV HTML content`, e_event.STDOUT_INFO);

--- a/packages/colibri/tests/sandpiper/sandpiper.spec.ts
+++ b/packages/colibri/tests/sandpiper/sandpiper.spec.ts
@@ -67,7 +67,8 @@ describe("Sandpiper", () => {
     const mockResponse = {
       status: 200,
       data: {
-        'out/sample.m4out_graph.svg': '<svg>Diagram content</svg>'
+             'out/sample.m4out_graph.svg': '<svg>M4 Diagram content</svg>',
+      'out/sample.m5out_graph.svg': '<svg>M5 Diagram content</svg>'
       }
     };
     (axios.post as jest.Mock).mockResolvedValue(mockResponse);
@@ -91,7 +92,8 @@ describe("Sandpiper", () => {
     const mockResponse = {
       status: 200,
       data: {
-        'out/sample.m4out.html': '<html>NavTLV content</html>'
+        'out/sample.m4out.html': '<html>m4 NavTLV content</html>',
+        'out/sample.m5out.html': '<html>m5 NavTLV content</html>'
       }
     };
     (axios.post as jest.Mock).mockResolvedValue(mockResponse);

--- a/packages/teroshdl/src/features/tree_views/project/element.ts
+++ b/packages/teroshdl/src/features/tree_views/project/element.ts
@@ -64,7 +64,7 @@ export class Project extends vscode.TreeItem {
             iconName = "quartus";
         }
         else if (projectType === teroshdl2.project_manager.common.e_project_type.SANDPIPER) {
-            this.description = "Sandpiper Project";
+            this.description = "TL-Verilog Project";
         }
         
         if (isOpen) {

--- a/packages/teroshdl/src/features/tree_views/project/manager.ts
+++ b/packages/teroshdl/src/features/tree_views/project/manager.ts
@@ -93,8 +93,8 @@ export class Project_manager extends BaseView {
             "Load project from YAML EDAM",
             "Load project from VUnit run.py",
             "Load an example project",
-            "Create an empty SandPiper project",
-            "Load an existing SandPiper project",
+            "Create an empty TL-Verilog project",
+            "Load an existing TL-Verilog project",
         ];
 
         const picker_value = await vscode.window.showQuickPick(PROJECT_ADD_TYPES, {

--- a/packages/teroshdl/src/features/tree_views/tasks/sandpiper_logger.ts
+++ b/packages/teroshdl/src/features/tree_views/tasks/sandpiper_logger.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ProjectEmitter } from 'teroshdl2/out/project_manager/projectEmitter';
 import { e_event } from 'teroshdl2/out/project_manager/projectEmitter';
 
-const outputChannel = vscode.window.createOutputChannel('Sandpiper Logs');
+const outputChannel = vscode.window.createOutputChannel('TL-Verilog Logs');
 
 export function sandpiperLogger(emitterProject: ProjectEmitter) {
     emitterProject.addProjectListener(async (log: string, type: e_event) => {

--- a/packages/teroshdl/src/features/tree_views/tasks/sandpiper_utils.ts
+++ b/packages/teroshdl/src/features/tree_views/tasks/sandpiper_utils.ts
@@ -29,7 +29,7 @@ export async function runSandpiperConversion(
             return;
         }
 
-        vscode.window.showInformationMessage('Starting Sandpiper TL-Verilog to Verilog conversion...');
+        vscode.window.showInformationMessage('Starting TL-Verilog to Verilog conversion...');
 
         await teroshdl2.project_manager.sandpiper.runTLVerilogToVerilogConversion(
             selectedProject.get_config(),
@@ -39,9 +39,9 @@ export async function runSandpiperConversion(
             currentFileName
         );
 
-        vscode.window.showInformationMessage('Sandpiper TL-Verilog to Verilog conversion completed.');
+        vscode.window.showInformationMessage('TL-Verilog to Verilog conversion completed.');
     } catch (error) {
-        vscode.window.showErrorMessage(`Error during Sandpiper conversion: ${error}`);
+        vscode.window.showErrorMessage(`Error during SandPiper conversion: ${error}`);
     }
 }
 export async function runSandpiperDiagramGeneration(
@@ -65,7 +65,7 @@ export async function runSandpiperDiagramGeneration(
             return;
         }
 
-        vscode.window.showInformationMessage('Starting Sandpiper diagram generation...');
+        vscode.window.showInformationMessage('Starting Diagram generation...');
 
         // First, run the task
         await new Promise<void>((resolve, reject) => {
@@ -91,16 +91,16 @@ export async function runSandpiperDiagramGeneration(
         );
 
         showSvgInWebview(svgFilePath);
-        vscode.window.showInformationMessage('Sandpiper diagram generated and displayed.');
+        vscode.window.showInformationMessage('Diagram generated and displayed.');
     } catch (error) {
-        vscode.window.showErrorMessage(`Error during Sandpiper diagram generation: ${error}`);
+        vscode.window.showErrorMessage(`Error during SandPiper diagram generation: ${error}`);
     }
 }
 
 function showSvgInWebview(svgFilePath: string) {
     const panel = vscode.window.createWebviewPanel(
-        'sandpiperDiagram',
-        'Sandpiper Diagram Viewer',
+        'TL-Verilog Diagram',
+        'TL-Verilog Diagram Viewer',
         vscode.ViewColumn.Two,
         {
             enableScripts: true,
@@ -115,7 +115,7 @@ function showSvgInWebview(svgFilePath: string) {
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Sandpiper Diagram Viewer</title>
+        <title>TL-Verilog Diagram Viewer</title>
         <style>
             body { 
                 margin: 0; 
@@ -231,7 +231,7 @@ export async function runSandpiperNavTlvGeneration(
             return;
         }
 
-        vscode.window.showInformationMessage('Starting Sandpiper NavTLV generation...');
+        vscode.window.showInformationMessage('Starting NavTLV generation...');
 
         // Run the task
         await new Promise<void>((resolve, reject) => {
@@ -293,7 +293,7 @@ function showNavTlvInWebview(navTlvHtml: string) {
         <body>
             <div class="nav-tlv-content">${navTlvHtml}</div>
             <script>
-                // You can add any necessary JavaScript here
+                // to be added
             </script>
         </body>
         </html>


### PR DESCRIPTION
This PR enhances the existing functionality to support both m4out and m5out outputs generated by SandPiper SaaS, ensuring that the correct SVG diagram is processed and saved regardless of the output format. Also, used 'SandPiper' name instead of Sandpiper