### PR TITLE
Update vhdl.configuration.json to enable --#region --#endregion for VHDL

### DIFF
--- a/packages/teroshdl/configs/systemverilog.configuration.json
+++ b/packages/teroshdl/configs/systemverilog.configuration.json
@@ -52,8 +52,8 @@
 		},
 		"folding": {
 			"markers": {
-				"start": "^\\s*(`celldefine|`ifdef|`ifndef|`pragma\\s+protect\\b.*\\b(begin|begin_protected)\\b|`unconnected_drive)\\b|^\\s*(((priority|unique|unique0)\\s+)?(case|casex|casez)|checker|(virtual\\s+)?class|config|covergroup|generate|interface|module|package|primitive|program|property|randcase|randsequence|sequence|specify|(virtual\\s+)?((local|protected|static)\\s+)?(function|task))\\b|^((?!\\/\\/|\\/\\*).)*\\bbegin\\b(?!.*\\bend\\b)|^((?!\\/\\/|\\/\\*|\\bdisable\\b|\\bwait\\b).)*\\bfork\\b(?!.*\\b(join(_any|_none|))\\b)|^((?!\\/\\/|\\/\\*).)*\\{\\s*((\\/\\/|\\/\\*).*|$)|^\\s*((default|global)\\s+)?(clocking\\b).*\\@",
-				"end": "^\\s*(`endcelldefine|`endif|`nounconnected_drive|`pragma\\s+protect\\b.*\\b(end|end_protected)|`resetall)\\b|^\\s*(end(case|checker|class|clocking|config|function|generate|group|interface|module|package|primitive|program|property|sequence|specify|task)\\b)|^\\s*end\\b|^\\s*join(_any|_none|)\\b|^\\s*\\}"
+				"start": "^\\s*(`celldefine|`ifdef|`ifndef|`pragma\\s+protect\\b.*\\b(begin|begin_protected)\\b|`unconnected_drive)\\b|^\\s*(((priority|unique|unique0)\\s+)?(case|casex|casez)|checker|(virtual\\s+)?class|config|covergroup|generate|interface|module|package|primitive|program|property|randcase|randsequence|sequence|specify|(virtual\\s+)?((local|protected|static)\\s+)?(function|task))\\b|^((?!\\/\\/|\\/\\*).)*\\bbegin\\b(?!.*\\bend\\b)|^((?!\\/\\/|\\/\\*|\\bdisable\\b|\\bwait\\b).)*\\bfork\\b(?!.*\\b(join(_any|_none|))\\b)|^((?!\\/\\/|\\/\\*).)*\\{\\s*((\\/\\/|\\/\\*).*|$)|^\\s*((default|global)\\s+)?(clocking\\b).*\\@|^\\s*//\\s*#?region\\b",
+				"end": "^\\s*(`endcelldefine|`endif|`nounconnected_drive|`pragma\\s+protect\\b.*\\b(end|end_protected)|`resetall)\\b|^\\s*(end(case|checker|class|clocking|config|function|generate|group|interface|module|package|primitive|program|property|sequence|specify|task)\\b)|^\\s*end\\b|^\\s*join(_any|_none|)\\b|^\\s*\\}|^\\s*//\\s*#?endregion\\b"
 			}
 		}
 }

--- a/packages/teroshdl/configs/tcl.configuration.json
+++ b/packages/teroshdl/configs/tcl.configuration.json
@@ -6,5 +6,11 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"]
-    ]
+    ],
+    "folding": {
+      "markers": {
+        "start": "^\\s*#region\\b",
+        "end": "^\\s*#endregion\\b"
+      }
+    }
 }

--- a/packages/teroshdl/configs/verilog.configuration.json
+++ b/packages/teroshdl/configs/verilog.configuration.json
@@ -52,8 +52,8 @@
 		},
 		"folding": {
 			"markers": {
-				"start": "^\\s*(`celldefine|`ifdef|`ifndef|`pragma\\s+protect\\b.*\\b(begin|begin_protected)\\b|`unconnected_drive)\\b|^\\s*(((priority|unique|unique0)\\s+)?(case|casex|casez)|checker|(virtual\\s+)?class|config|covergroup|generate|interface|module|package|primitive|program|property|randcase|randsequence|sequence|specify|(virtual\\s+)?((local|protected|static)\\s+)?(function|task))\\b|^((?!\\/\\/|\\/\\*).)*\\bbegin\\b(?!.*\\bend\\b)|^((?!\\/\\/|\\/\\*|\\bdisable\\b|\\bwait\\b).)*\\bfork\\b(?!.*\\b(join(_any|_none|))\\b)|^((?!\\/\\/|\\/\\*).)*\\{\\s*((\\/\\/|\\/\\*).*|$)|^\\s*((default|global)\\s+)?(clocking\\b).*\\@",
-				"end": "^\\s*(`endcelldefine|`endif|`nounconnected_drive|`pragma\\s+protect\\b.*\\b(end|end_protected)|`resetall)\\b|^\\s*(end(case|checker|class|clocking|config|function|generate|group|interface|module|package|primitive|program|property|sequence|specify|task)\\b)|^\\s*end\\b|^\\s*join(_any|_none|)\\b|^\\s*\\}"
+				"start": "^\\s*(`celldefine|`ifdef|`ifndef|`pragma\\s+protect\\b.*\\b(begin|begin_protected)\\b|`unconnected_drive)\\b|^\\s*(((priority|unique|unique0)\\s+)?(case|casex|casez)|checker|(virtual\\s+)?class|config|covergroup|generate|interface|module|package|primitive|program|property|randcase|randsequence|sequence|specify|(virtual\\s+)?((local|protected|static)\\s+)?(function|task))\\b|^((?!\\/\\/|\\/\\*).)*\\bbegin\\b(?!.*\\bend\\b)|^((?!\\/\\/|\\/\\*|\\bdisable\\b|\\bwait\\b).)*\\bfork\\b(?!.*\\b(join(_any|_none|))\\b)|^((?!\\/\\/|\\/\\*).)*\\{\\s*((\\/\\/|\\/\\*).*|$)|^\\s*((default|global)\\s+)?(clocking\\b).*\\@|^\\s*//\\s*#?region\\b",
+				"end": "^\\s*(`endcelldefine|`endif|`nounconnected_drive|`pragma\\s+protect\\b.*\\b(end|end_protected)|`resetall)\\b|^\\s*(end(case|checker|class|clocking|config|function|generate|group|interface|module|package|primitive|program|property|sequence|specify|task)\\b)|^\\s*end\\b|^\\s*join(_any|_none|)\\b|^\\s*\\}|^\\s*//\\s*#?endregion\\b"
 			}
 		}
 }

--- a/packages/teroshdl/configs/vhdl.configuration.json
+++ b/packages/teroshdl/configs/vhdl.configuration.json
@@ -34,5 +34,12 @@
         "decreaseIndentPattern": "^((?!.*?\\/\\*).*\\*/)?\\s*(elsif|else|end|begin)\\b",
         // `^((?!.*?/\*).*\*/)??` ignore any text in a comment at the start of the line
         // `\s*(elsif|else|end|begin)\b)` decrease indent on a line starting with these keywords
+    },
+
+    "folding": { // enable folding/minimap labels for --#region <Label> ... --#endregion <Label>
+        "markers": {
+            "start": "^\\s*\\-\\-\\s*#?region\\b",
+            "end": "^\\s*\\-\\-\\s*#?endregion\\b"
+        }
     }
 }

--- a/packages/teroshdl/configs/xdcconstraints.configuration.json
+++ b/packages/teroshdl/configs/xdcconstraints.configuration.json
@@ -21,5 +21,11 @@
       ["(", ")"],
       ["\"", "\""],
       ["'", "'"]
-  ]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*#region\\b",
+      "end": "^\\s*#endregion\\b"
+    }
+  }
 }


### PR DESCRIPTION
enable folding/minimap labels for regions in VHDL

use
```
  --#region SomeLabel
    [...]
  --#endregion SomeLabel
```
in `.vhdl` sources to group code regions and show `SomeLabel` markers on the minimap of VSCode