### PR TITLE
allow custom version arguments for external tools

### DIFF
--- a/src/teroshdl/features/configChecker/externalTools.ts
+++ b/src/teroshdl/features/configChecker/externalTools.ts
@@ -37,9 +37,17 @@ export async function checkExternalToolManager(currentConfig: e_config) {
 
     msg += buildTitle('Checking External Tool Configuration', HELP);
 
+    // Build a custom map for specified extern tools' version check argument
+    const customVersionArgs: Record<string, string> = {
+        vivado: '-version',
+        // Add more tools and their custom arguments here
+        // "tool-name-example": "--example-arg"
+    };
+
     // Check external tool
     msg += `${INTROICON} Selected external tool: ${selectedTool.toLocaleUpperCase()}. Installation path: "${installationPath}"\n`;
-    let result = await checkBinary(selectedTool, installationPath, selectedTool.toLocaleLowerCase(), ['--version']);
+    const versionArgument = customVersionArgs[toolKey] || '--version'; // Default to '--version' if no custom argument is specified
+    let result = await checkBinary(selectedTool, installationPath, selectedTool.toLocaleLowerCase(), [versionArgument]);
     msg = appendMsg(result, msg, selectedTool.toLocaleUpperCase());
     msg += '\n';
     if (!result.successfulConfig) {


### PR DESCRIPTION
- Added a `customVersionArgs` map to define tool-specific version arguments.
- Default version argument is `--version` unless overridden by the map.
- Enhanced flexibility to support tools like "vivado" requiring `-version`.
- Simplified logic for future extensibility by allowing additional tool-argument pairs.