### PR TITLE
add custom version check arguments for external tools

### DIFF
--- a/src/teroshdl/features/configChecker/externalTools.ts
+++ b/src/teroshdl/features/configChecker/externalTools.ts
@@ -37,9 +37,18 @@ export async function checkExternalToolManager(currentConfig: e_config) {
 
     msg += buildTitle('Checking External Tool Configuration', HELP);
 
+    // Build a custom map for specified extern tools' version check argument
+    const customVersionArgs: Record<string, string> = {
+        vivado: '-version',
+        iverilog: '-V'
+        // Add more tools and their custom arguments here
+        // "tool-name-example": "--example-arg"
+    };
+
     // Check external tool
     msg += `${INTROICON} Selected external tool: ${selectedTool.toLocaleUpperCase()}. Installation path: "${installationPath}"\n`;
-    let result = await checkBinary(selectedTool, installationPath, selectedTool.toLocaleLowerCase(), ['--version']);
+    const versionArgument = customVersionArgs[selectedTool] || '--version'; // Default to '--version' if no custom argument is specified
+    let result = await checkBinary(selectedTool, installationPath, selectedTool.toLocaleLowerCase(), [versionArgument]);
     msg = appendMsg(result, msg, selectedTool.toLocaleUpperCase());
     msg += '\n';
     if (!result.successfulConfig) {


### PR DESCRIPTION
- Introduced a custom map `customVersionArgs` to define version check arguments for specific tools.
- Added support for Vivado with `-version` and Icarus Verilog (iverilog) with `-V`.
- Included placeholders for adding more tools in the future.- Updated the version check logic to use custom arguments if specified, defaulting to `--version` otherwise.
- Enhanced logging to reflect the selected tool and its installation path.

This improves flexibility in handling version checks for external tools.