### PR TITLE
Improve multiline comment parsing and support GFM-style line breaks in documentation

### DIFF
--- a/src/colibri/documenter/utils.ts
+++ b/src/colibri/documenter/utils.ts
@@ -26,7 +26,9 @@ export function normalize_description(description: string): string {
     if(!description){
         return "";
     }
-    let desc_inst = description.replace(/\n\s*\n/g, '<br> ');
+
+    let desc_inst = description.replace(/\s{2,}\n/g, '<br> ');
+    desc_inst = desc_inst.replace(/\n\s*\n/g, '<br> ');
     desc_inst = desc_inst.replace(/\n/g, ' ');
     desc_inst = desc_inst.replace(/<br \/>/g, ' ');
     return desc_inst;

--- a/src/colibri/parser/ts_base_parser.ts
+++ b/src/colibri/parser/ts_base_parser.ts
@@ -20,7 +20,7 @@
 export class Ts_base_parser {
     comment_symbol = "";
 
-    protected get_comment(comment: string, multiline_delete = true) {
+    protected get_comment(comment: string, multiline_delete = false) {
         let break_line = '\n';
         if (multiline_delete === true) {
             break_line = '';


### PR DESCRIPTION
This pull request introduces two key improvements to the comment handling and documentation generation logic in TerosHDL:

---

## ✅ 1. Fix: Preserve line breaks in multiline comment strings

The method `get_comment()` in `ts_base_parser.ts` previously removed line breaks by default via `multiline_delete = true`.  
This behavior led to unintuitive and flat comment formatting, especially in documentation generation.

### ✔️ What changed:

- The default value of `multiline_delete` is now `false`, meaning line breaks are preserved by default.
- Since the method is only used for documentation-related purposes, no other parts of the code needed to be modified.

**Result:** Comments keep their intended formatting without forcing line joins or manual `<br>` tags.

---

## ✅ 2. Enhancement: GitHub-Flavored Markdown line break support

The `normalize_description()` function now properly respects Markdown's rule for hard line breaks:

> A line that ends with two or more spaces, followed by a newline (`␣␣\n`), should be rendered with a `<br>` in HTML.

### ✔️ What changed:

- Lines ending with at least two spaces are now detected with `\s{2,}\n` and replaced by `<br>`.
- Double newlines (paragraphs) are still replaced by `<br>`.
- Remaining soft line breaks (`\n`) are flattened to spaces.
- Legacy replacements of `<br />` are retained for compatibility.

---

## 🎯 Why this matters

TerosHDL is not just a syntax parser – it’s also a documentation generator.  
These changes make it possible to write readable, semantically correct, multi-line comments like:

```vhdl
    --@ Read AXI flag generation  
    --@ The read AXI flag is generated by comparing the read pointer with the write pointer
    --@ synchronized to the read clock.
    --@ If the read pointer is equal to the write pointer
    --@ the FIFO is empty and the `Valid` signal is set to `0`.
    P_ReadAXIFlag : process (R_Read_Pointer, R_Write_PointerSync)
    begin
        if R_Read_Pointer = R_Write_PointerSync then
            C_Read_Valid <= '0';
        else
            C_Read_Valid <= '1';
        end if;
    end process P_ReadAXIFlag;
```

...and have them rendered correctly **without requiring `<br>` inside the source code.**  
This improves code readability and documentation hygiene at the same time.

---

## ✨ Summary

- Clean separation of code and presentation logic
- More intuitive documentation formatting
- Less HTML noise in HDL comments
- Improved Markdown compliance (GFM-style)