### PR TITLE
fix: handle different shell error message formats in process tests

### DIFF
--- a/tests/process/process.spec.ts
+++ b/tests/process/process.spec.ts
@@ -54,7 +54,10 @@ describe("Process", () => {
         expect(result.command).toBe(cmd);
         expect(result.return_value).toBe(-1);
         if (process.platform !== 'win32') {
-            expect(result.stderr).toBe("/bin/sh: 1: asdf: not found");
+            // Handle different shell error message formats
+            // dash: "/bin/sh: 1: asdf: not found"
+            // bash: "/bin/sh: line 1: asdf: command not found"
+            expect(result.stderr).toMatch(/\/bin\/sh: (line )?1: asdf: (command )?not found/);
         }
         expect(result.stdout).toBe("");
         expect(result.successful).not.toBeTruthy();
@@ -141,7 +144,10 @@ describe("Process", () => {
             expect(result.command).toBe(cmd);
             expect(result.return_value).toBe(-1);
             if (process.platform !== 'win32') {
-                expect(result.stderr).toBe("/bin/sh: 1: asdf: not found");
+                // Handle different shell error message formats
+                // dash: "/bin/sh: 1: asdf: not found"
+                // bash: "/bin/sh: line 1: asdf: command not found"
+                expect(result.stderr).toMatch(/\/bin\/sh: (line )?1: asdf: (command )?not found/);
             }
             expect(result.stdout).toBe("");
             expect(result.successful).not.toBeTruthy();

--- a/tests_impr/process/process.spec.ts
+++ b/tests_impr/process/process.spec.ts
@@ -60,6 +60,13 @@ describe('Test local process', function () {
         if (os === 'darwin' || os === 'win32') {
             expected_result.stderr = '';
             result.stderr = '';
+        } else {
+            // Handle different shell error message formats on Linux
+            // dash: "/bin/sh: 1: asdf: not found"
+            // bash: "/bin/sh: line 1: asdf: command not found"
+            expect(result.stderr).toMatch(/\/bin\/sh: (line )?1: asdf: (command )?not found/);
+            // Clear stderr for deepEqual comparison
+            expected_result.stderr = result.stderr;
         }
         deepEqual(result, expected_result);
     });


### PR DESCRIPTION
# Fix shell error message compatibility across different Linux distributions

## 🐛 Problem

The process tests were failing on systems where sh is symlinked to `bash` instead of `dash`, due to different error message formats when executing non-existent commands.

**Expected (dash shell):**
```
/bin/sh: 1: asdf: not found
```

**Actual (bash shell):**
```
/bin/sh: line 1: asdf: command not found
```

This caused test failures with the error:
```
Expected: "/bin/sh: 1: asdf: not found"
Received: "/bin/sh: line 1: asdf: command not found"
```

## 🔧 Solution

Updated test assertions to use flexible regex patterns that accommodate both shell error message formats:

```typescript
expect(result.stderr).toMatch(/\/bin\/sh: (line )?1: asdf: (command )?not found/);
```

## 🧪 Regex Pattern Breakdown

The pattern `/\/bin\/sh: (line )?1: asdf: (command )?not found/` handles:

- `\/bin\/sh: ` - Literal shell prefix
- `(line )?` - Optional "line " prefix (bash format)
- `1: ` - Line number
- `asdf: ` - Command name
- `(command )?` - Optional "command " prefix (bash format)
- `not found` - Error suffix
