### PR TITLE
#797 enhance VSG formatting command and error logging

### DIFF
--- a/src/colibri/formatter/vsg.ts
+++ b/src/colibri/formatter/vsg.ts
@@ -47,24 +47,69 @@ export class Vsg extends Base_formatter {
     }
 
     public async format(file: string, opt: cfg.e_tools_vsg, _python_path: string) {
-        let command = `${this.binary} ${opt.aditional_arguments} -p ${opt.core_number} --fix -f ${file}`;
+        // Use full path or installation path if provided
+        const binary_path = opt.installation_path ? 
+            `${opt.installation_path}/${this.binary}` : this.binary;
+            
+        let command = `${binary_path} ${opt.aditional_arguments} -p ${opt.core_number} --fix -f ${file}`;
         if (opt.style_config !== ""){
             // eslint-disable-next-line max-len
-            command = `${this.binary} ${opt.aditional_arguments} -p ${opt.core_number} --fix -c ${opt.style_config} -f ${file}`;
+            command = `${binary_path} ${opt.aditional_arguments} -p ${opt.core_number} --fix -c ${opt.style_config} -f ${file}`;
         }
 
+        // For platform compatibility, try with shell execution
+        const shell_command = `/bin/bash -c "${command}"`;
+
         const P = new Process();
-        const exec_result = await P.exec_wait(command);
+        const exec_result = await P.exec_wait(shell_command);
+        
+        // Check if the file was actually modified by comparing timestamps or content
+        const file_exists = fs.existsSync(file);
+        if (!file_exists) {
+            const result: common.f_result = {
+                code_formatted: "",
+                command: command,
+                successful: false,
+                message: "VSG failed: temp file was deleted or not found",
+            };
+            return result;
+        }
+        
         const code_formatted = fs.readFileSync(file, "utf8");
 
         const msg = `Formatting with command: ${command} `;
         logger.Logger.log(msg);
+        
+        // Debug logging for platform-specific issues
+        logger.Logger.log(`VSG execution result - successful: ${exec_result.successful}, ` +
+                         `return_value: ${exec_result.return_value}`);
+        logger.Logger.log(`VSG stdout: ${exec_result.stdout}`);
+        logger.Logger.log(`VSG stderr: ${exec_result.stderr}`);
+
+        // Check for VHDL syntax errors in VSG output
+        const has_syntax_error = exec_result.stderr.includes("Unexpected token") || 
+                                exec_result.stderr.includes("Error while processing") ||
+                                exec_result.stderr.includes("Expecting :");
+
+        if (has_syntax_error) {
+            const result: common.f_result = {
+                code_formatted: code_formatted, // Return original code
+                command: command,
+                successful: false,
+                message: `VSG failed due to VHDL syntax error: ${exec_result.stderr}`,
+            };
+            return result;
+        }
+
+        // Consider the formatting successful if the command executed without error
+        // even if no violations were found
+        const formatting_successful = exec_result.successful && exec_result.return_value === 0;
 
         const result: common.f_result = {
             code_formatted: code_formatted,
             command: command,
-            successful: true,
-            message: exec_result.stderr,
+            successful: formatting_successful,
+            message: exec_result.stderr || exec_result.stdout,
         };
         return result;
     }

--- a/src/teroshdl/features/formatter.ts
+++ b/src/teroshdl/features/formatter.ts
@@ -117,6 +117,32 @@ class Formatter {
         if (result.successful === false){
             globalLogger.info("Error format code.");
             globalLogger.debug(result.command);
+            
+            // Add detailed error information
+            if (result.message) {
+                globalLogger.error(`Formatter error details: ${result.message}`);
+                
+                // Extract line and column information from VSG error messages
+                const lineMatch = result.message.match(/@ Line (\d+), Column (\d+)/);
+                if (lineMatch) {
+                    const line = lineMatch[1];
+                    const column = lineMatch[2];
+                    globalLogger.error(`Error location: Line ${line}, Column ${column}`);
+                }
+                
+                // Extract expected vs found information
+                const expectingMatch = result.message.match(/Expecting : (.+)/);
+                const foundMatch = result.message.match(/Found     : (.+)/);
+                if (expectingMatch && foundMatch) {
+                    globalLogger.error(`Expected: '${expectingMatch[1].trim()}', Found: '${foundMatch[1].trim()}'`);
+                }
+                
+                // Extract file processing error
+                const fileErrorMatch = result.message.match(/Error while processing (.+?):/);
+                if (fileErrorMatch) {
+                    globalLogger.error(`Failed to process file: ${fileErrorMatch[1]}`);
+                }
+            }
         }
         else{
             globalLogger.info("The code has been formatted successfully.");


### PR DESCRIPTION
enhance VSG formatting command and error logging. 
fix #797 

correct vhdl:
`The code has been formatted successfully.`

vhdl with format error:
```
Error format code.vsg  -p 2 --fix -f /tmp/f-2025914-6811-1k11zym.lbleFormatter error details: VSG failed due to VHDL syntax error: Error while processing /tmp/f-2025914-6811-1k11zym.lble: 
Error: Unexpected token detected while parsing architecture_body @ Line 30, Column 1 in file None
       Expecting : end
       Found     : half_adderError location: Line 30, Column 1Expected: 'end', Found: 'half_adder'Failed to process file: /tmp/f-2025914-6811-1k11zym.lble
```