### PR TITLE
Waveform support

### DIFF
--- a/src/colibri/config/config_declaration.ts
+++ b/src/colibri/config/config_declaration.ts
@@ -227,7 +227,7 @@ export type e_tools_general = {
     manual_compilation_order : string,
     execution_mode : e_tools_general_execution_mode,
     waveform_viewer : e_tools_general_waveform_viewer,
-    vaporview_import_signals : boolean,
+    vaporview_load_all_signals : boolean,
     gtkwave_installation_path : string,
     gtkwave_extra_arguments : string,
     surfer_installation_path : string,
@@ -1117,7 +1117,7 @@ export function get_default_config(): e_config {
                 manual_compilation_order : "",
                 execution_mode : e_tools_general_execution_mode.cmd,
                 waveform_viewer : e_tools_general_waveform_viewer.tool,
-                vaporview_import_signals : true,
+                vaporview_load_all_signals : true,
                 gtkwave_installation_path : "",
                 gtkwave_extra_arguments : "",
                 surfer_installation_path : "",
@@ -2449,14 +2449,14 @@ export function get_config_from_json(json_config: any): e_config {
         default_config['tools']['general']['waveform_viewer'] = e_tools_general_waveform_viewer.surfer;
     }
             
-    // tools -> general -> vaporview_import_signals
+    // tools -> general -> vaporview_load_all_signals
     let current_value_75 = undefined;
     try {
-        current_value_75 = json_config['tools']['general']['vaporview_import_signals'];
+        current_value_75 = json_config['tools']['general']['vaporview_load_all_signals'];
     }
     catch(e){}
     if (current_value_75 === true || current_value_75 === false){
-        default_config['tools']['general']['vaporview_import_signals'] = current_value_75;
+        default_config['tools']['general']['vaporview_load_all_signals'] = current_value_75;
     }
             
     // tools -> general -> gtkwave_installation_path

--- a/src/colibri/config/config_declaration.ts
+++ b/src/colibri/config/config_declaration.ts
@@ -227,9 +227,10 @@ export type e_tools_general = {
     manual_compilation_order : string,
     execution_mode : e_tools_general_execution_mode,
     waveform_viewer : e_tools_general_waveform_viewer,
+    vaporview_import_signals : boolean,
     gtkwave_installation_path : string,
-    surfer_installation_path : string,
     gtkwave_extra_arguments : string,
+    surfer_installation_path : string,
     surfer_extra_arguments : string,
 };
     
@@ -1116,6 +1117,7 @@ export function get_default_config(): e_config {
                 manual_compilation_order : "",
                 execution_mode : e_tools_general_execution_mode.cmd,
                 waveform_viewer : e_tools_general_waveform_viewer.tool,
+                vaporview_import_signals : true,
                 gtkwave_installation_path : "",
                 gtkwave_extra_arguments : "",
                 surfer_installation_path : "",
@@ -2443,2984 +2445,3017 @@ export function get_config_from_json(json_config: any): e_config {
     if ( current_value_74 === "gtkwave"){
         default_config['tools']['general']['waveform_viewer'] = e_tools_general_waveform_viewer.gtkwave;
     }
+    if ( current_value_74 === "surfer"){
+        default_config['tools']['general']['waveform_viewer'] = e_tools_general_waveform_viewer.surfer;
+    }
             
-    // tools -> general -> gtkwave_installation_path
+    // tools -> general -> vaporview_import_signals
     let current_value_75 = undefined;
     try {
-        current_value_75 = json_config['tools']['general']['gtkwave_installation_path'];
+        current_value_75 = json_config['tools']['general']['vaporview_import_signals'];
     }
     catch(e){}
-    if (typeof current_value_75 === 'string'){
-        default_config['tools']['general']['gtkwave_installation_path'] = current_value_75;
+    if (current_value_75 === true || current_value_75 === false){
+        default_config['tools']['general']['vaporview_import_signals'] = current_value_75;
     }
             
-    // tools -> general -> gtkwave_extra_arguments
+    // tools -> general -> gtkwave_installation_path
     let current_value_76 = undefined;
     try {
-        current_value_76 = json_config['tools']['general']['gtkwave_extra_arguments'];
+        current_value_76 = json_config['tools']['general']['gtkwave_installation_path'];
     }
     catch(e){}
     if (typeof current_value_76 === 'string'){
-        default_config['tools']['general']['gtkwave_extra_arguments'] = current_value_76;
+        default_config['tools']['general']['gtkwave_installation_path'] = current_value_76;
     }
             
-    // tools -> quartus -> installation_path
+    // tools -> general -> gtkwave_extra_arguments
     let current_value_77 = undefined;
     try {
-        current_value_77 = json_config['tools']['quartus']['installation_path'];
+        current_value_77 = json_config['tools']['general']['gtkwave_extra_arguments'];
     }
     catch(e){}
     if (typeof current_value_77 === 'string'){
-        default_config['tools']['quartus']['installation_path'] = current_value_77;
+        default_config['tools']['general']['gtkwave_extra_arguments'] = current_value_77;
     }
             
-    // tools -> quartus -> family
+    // tools -> general -> surfer_installation_path
     let current_value_78 = undefined;
     try {
-        current_value_78 = json_config['tools']['quartus']['family'];
+        current_value_78 = json_config['tools']['general']['surfer_installation_path'];
     }
     catch(e){}
     if (typeof current_value_78 === 'string'){
-        default_config['tools']['quartus']['family'] = current_value_78;
+        default_config['tools']['general']['surfer_installation_path'] = current_value_78;
     }
             
-    // tools -> quartus -> device
+    // tools -> general -> surfer_extra_arguments
     let current_value_79 = undefined;
     try {
-        current_value_79 = json_config['tools']['quartus']['device'];
+        current_value_79 = json_config['tools']['general']['surfer_extra_arguments'];
     }
     catch(e){}
     if (typeof current_value_79 === 'string'){
-        default_config['tools']['quartus']['device'] = current_value_79;
+        default_config['tools']['general']['surfer_extra_arguments'] = current_value_79;
+    }
+            
+    // tools -> quartus -> installation_path
+    let current_value_80 = undefined;
+    try {
+        current_value_80 = json_config['tools']['quartus']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_80 === 'string'){
+        default_config['tools']['quartus']['installation_path'] = current_value_80;
+    }
+            
+    // tools -> quartus -> family
+    let current_value_81 = undefined;
+    try {
+        current_value_81 = json_config['tools']['quartus']['family'];
+    }
+    catch(e){}
+    if (typeof current_value_81 === 'string'){
+        default_config['tools']['quartus']['family'] = current_value_81;
+    }
+            
+    // tools -> quartus -> device
+    let current_value_82 = undefined;
+    try {
+        current_value_82 = json_config['tools']['quartus']['device'];
+    }
+    catch(e){}
+    if (typeof current_value_82 === 'string'){
+        default_config['tools']['quartus']['device'] = current_value_82;
     }
             
     // tools -> quartus -> optimization_mode
-    let current_value_80 = undefined;
+    let current_value_83 = undefined;
     try {
-        current_value_80 = json_config['tools']['quartus']['optimization_mode'];
+        current_value_83 = json_config['tools']['quartus']['optimization_mode'];
     }
     catch(e){}
-    if ( current_value_80 === "BALANCED"){
+    if ( current_value_83 === "BALANCED"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.BALANCED;
     }
-    if ( current_value_80 === "HIGH_PERFORMANCE_EFFORT"){
+    if ( current_value_83 === "HIGH_PERFORMANCE_EFFORT"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.HIGH_PERFORMANCE_EFFORT;
     }
-    if ( current_value_80 === "HIGH_PERFORMANCE_EFFORT_WITH_MAXIMUM_PLACEMENT_EFFORT"){
+    if ( current_value_83 === "HIGH_PERFORMANCE_EFFORT_WITH_MAXIMUM_PLACEMENT_EFFORT"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.HIGH_PERFORMANCE_EFFORT_WITH_MAXIMUM_PLACEMENT_EFFORT;
     }
-    if ( current_value_80 === "HIGH_PERFORMANCE_WITH_AGGRESSIVE_POWER_EFFORT"){
+    if ( current_value_83 === "HIGH_PERFORMANCE_WITH_AGGRESSIVE_POWER_EFFORT"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.HIGH_PERFORMANCE_WITH_AGGRESSIVE_POWER_EFFORT;
     }
-    if ( current_value_80 === "SUPERIOR_PERFORMANCE"){
+    if ( current_value_83 === "SUPERIOR_PERFORMANCE"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.SUPERIOR_PERFORMANCE;
     }
-    if ( current_value_80 === "SUPERIOR_PERFORMANCE_WITH_MAXIMUM_PLACEMENT_EFFORT"){
+    if ( current_value_83 === "SUPERIOR_PERFORMANCE_WITH_MAXIMUM_PLACEMENT_EFFORT"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.SUPERIOR_PERFORMANCE_WITH_MAXIMUM_PLACEMENT_EFFORT;
     }
-    if ( current_value_80 === "AGGRESSIVE_AREA"){
+    if ( current_value_83 === "AGGRESSIVE_AREA"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.AGGRESSIVE_AREA;
     }
-    if ( current_value_80 === "HIGH_PLACEMENT_ROUTABILITY_EFFORT"){
+    if ( current_value_83 === "HIGH_PLACEMENT_ROUTABILITY_EFFORT"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.HIGH_PLACEMENT_ROUTABILITY_EFFORT;
     }
-    if ( current_value_80 === "HIGH_PACKING_ROUTABILITY_EFFORT"){
+    if ( current_value_83 === "HIGH_PACKING_ROUTABILITY_EFFORT"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.HIGH_PACKING_ROUTABILITY_EFFORT;
     }
-    if ( current_value_80 === "OPTIMIZE_NETLIST_FOR_ROUTABILITY"){
+    if ( current_value_83 === "OPTIMIZE_NETLIST_FOR_ROUTABILITY"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.OPTIMIZE_NETLIST_FOR_ROUTABILITY;
     }
-    if ( current_value_80 === "AGGRESSIVE_POWER"){
+    if ( current_value_83 === "AGGRESSIVE_POWER"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.AGGRESSIVE_POWER;
     }
-    if ( current_value_80 === "AGGRESSIVE_COMPILE_TIME"){
+    if ( current_value_83 === "AGGRESSIVE_COMPILE_TIME"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.AGGRESSIVE_COMPILE_TIME;
     }
-    if ( current_value_80 === "FAST_FUNCTIONAL_TEST"){
+    if ( current_value_83 === "FAST_FUNCTIONAL_TEST"){
         default_config['tools']['quartus']['optimization_mode'] = e_tools_quartus_optimization_mode.FAST_FUNCTIONAL_TEST;
     }
             
     // tools -> quartus -> allow_register_retiming
-    let current_value_81 = undefined;
+    let current_value_84 = undefined;
     try {
-        current_value_81 = json_config['tools']['quartus']['allow_register_retiming'];
+        current_value_84 = json_config['tools']['quartus']['allow_register_retiming'];
     }
     catch(e){}
-    if (current_value_81 === true || current_value_81 === false){
-        default_config['tools']['quartus']['allow_register_retiming'] = current_value_81;
+    if (current_value_84 === true || current_value_84 === false){
+        default_config['tools']['quartus']['allow_register_retiming'] = current_value_84;
     }
             
     // tools -> quartus -> wave_file_questa
-    let current_value_82 = undefined;
+    let current_value_85 = undefined;
     try {
-        current_value_82 = json_config['tools']['quartus']['wave_file_questa'];
+        current_value_85 = json_config['tools']['quartus']['wave_file_questa'];
     }
     catch(e){}
-    if (typeof current_value_82 === 'string'){
-        default_config['tools']['quartus']['wave_file_questa'] = current_value_82;
+    if (typeof current_value_85 === 'string'){
+        default_config['tools']['quartus']['wave_file_questa'] = current_value_85;
     }
             
     // tools -> vsg -> installation_path
-    let current_value_83 = undefined;
-    try {
-        current_value_83 = json_config['tools']['vsg']['installation_path'];
-    }
-    catch(e){}
-    if (typeof current_value_83 === 'string'){
-        default_config['tools']['vsg']['installation_path'] = current_value_83;
-    }
-            
-    // tools -> vsg -> style_config
-    let current_value_84 = undefined;
-    try {
-        current_value_84 = json_config['tools']['vsg']['style_config'];
-    }
-    catch(e){}
-    if (typeof current_value_84 === 'string'){
-        default_config['tools']['vsg']['style_config'] = current_value_84;
-    }
-            
-    // tools -> vsg -> core_number
-    let current_value_85 = undefined;
-    try {
-        current_value_85 = json_config['tools']['vsg']['core_number'];
-    }
-    catch(e){}
-    if (typeof current_value_85 === 'number'){
-        default_config['tools']['vsg']['core_number'] = current_value_85;
-    }
-            
-    // tools -> vsg -> aditional_arguments
     let current_value_86 = undefined;
     try {
-        current_value_86 = json_config['tools']['vsg']['aditional_arguments'];
+        current_value_86 = json_config['tools']['vsg']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_86 === 'string'){
-        default_config['tools']['vsg']['aditional_arguments'] = current_value_86;
+        default_config['tools']['vsg']['installation_path'] = current_value_86;
     }
             
-    // tools -> osvvm -> installation_path
+    // tools -> vsg -> style_config
     let current_value_87 = undefined;
     try {
-        current_value_87 = json_config['tools']['osvvm']['installation_path'];
+        current_value_87 = json_config['tools']['vsg']['style_config'];
     }
     catch(e){}
     if (typeof current_value_87 === 'string'){
-        default_config['tools']['osvvm']['installation_path'] = current_value_87;
+        default_config['tools']['vsg']['style_config'] = current_value_87;
+    }
+            
+    // tools -> vsg -> core_number
+    let current_value_88 = undefined;
+    try {
+        current_value_88 = json_config['tools']['vsg']['core_number'];
+    }
+    catch(e){}
+    if (typeof current_value_88 === 'number'){
+        default_config['tools']['vsg']['core_number'] = current_value_88;
+    }
+            
+    // tools -> vsg -> aditional_arguments
+    let current_value_89 = undefined;
+    try {
+        current_value_89 = json_config['tools']['vsg']['aditional_arguments'];
+    }
+    catch(e){}
+    if (typeof current_value_89 === 'string'){
+        default_config['tools']['vsg']['aditional_arguments'] = current_value_89;
+    }
+            
+    // tools -> osvvm -> installation_path
+    let current_value_90 = undefined;
+    try {
+        current_value_90 = json_config['tools']['osvvm']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_90 === 'string'){
+        default_config['tools']['osvvm']['installation_path'] = current_value_90;
     }
             
     // tools -> osvvm -> tclsh_binary
-    let current_value_88 = undefined;
+    let current_value_91 = undefined;
     try {
-        current_value_88 = json_config['tools']['osvvm']['tclsh_binary'];
+        current_value_91 = json_config['tools']['osvvm']['tclsh_binary'];
     }
     catch(e){}
-    if (typeof current_value_88 === 'string'){
-        default_config['tools']['osvvm']['tclsh_binary'] = current_value_88;
+    if (typeof current_value_91 === 'string'){
+        default_config['tools']['osvvm']['tclsh_binary'] = current_value_91;
     }
             
     // tools -> osvvm -> simulator_name
-    let current_value_89 = undefined;
+    let current_value_92 = undefined;
     try {
-        current_value_89 = json_config['tools']['osvvm']['simulator_name'];
+        current_value_92 = json_config['tools']['osvvm']['simulator_name'];
     }
     catch(e){}
-    if ( current_value_89 === "activehdl"){
+    if ( current_value_92 === "activehdl"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.activehdl;
     }
-    if ( current_value_89 === "ghdl"){
+    if ( current_value_92 === "ghdl"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.ghdl;
     }
-    if ( current_value_89 === "nvc"){
+    if ( current_value_92 === "nvc"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.nvc;
     }
-    if ( current_value_89 === "rivierapro"){
+    if ( current_value_92 === "rivierapro"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.rivierapro;
     }
-    if ( current_value_89 === "questa"){
+    if ( current_value_92 === "questa"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.questa;
     }
-    if ( current_value_89 === "modelsim"){
+    if ( current_value_92 === "modelsim"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.modelsim;
     }
-    if ( current_value_89 === "vcs"){
+    if ( current_value_92 === "vcs"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.vcs;
     }
-    if ( current_value_89 === "xsim"){
+    if ( current_value_92 === "xsim"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.xsim;
     }
-    if ( current_value_89 === "xcelium"){
+    if ( current_value_92 === "xcelium"){
         default_config['tools']['osvvm']['simulator_name'] = e_tools_osvvm_simulator_name.xcelium;
     }
             
     // tools -> ascenlint -> installation_path
-    let current_value_90 = undefined;
+    let current_value_93 = undefined;
     try {
-        current_value_90 = json_config['tools']['ascenlint']['installation_path'];
+        current_value_93 = json_config['tools']['ascenlint']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_90 === 'string'){
-        default_config['tools']['ascenlint']['installation_path'] = current_value_90;
+    if (typeof current_value_93 === 'string'){
+        default_config['tools']['ascenlint']['installation_path'] = current_value_93;
     }
             
     // tools -> ascenlint -> ascentlint_options
-    let current_value_91 = undefined;
+    let current_value_94 = undefined;
     try {
-        current_value_91 = json_config['tools']['ascenlint']['ascentlint_options'];
+        current_value_94 = json_config['tools']['ascenlint']['ascentlint_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_91)){
-        default_config['tools']['ascenlint']['ascentlint_options'] = current_value_91;
+    if (Array.isArray(current_value_94)){
+        default_config['tools']['ascenlint']['ascentlint_options'] = current_value_94;
     }
             
     // tools -> cocotb -> installation_path
-    let current_value_92 = undefined;
+    let current_value_95 = undefined;
     try {
-        current_value_92 = json_config['tools']['cocotb']['installation_path'];
+        current_value_95 = json_config['tools']['cocotb']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_92 === 'string'){
-        default_config['tools']['cocotb']['installation_path'] = current_value_92;
+    if (typeof current_value_95 === 'string'){
+        default_config['tools']['cocotb']['installation_path'] = current_value_95;
     }
             
     // tools -> cocotb -> simulator_name
-    let current_value_93 = undefined;
+    let current_value_96 = undefined;
     try {
-        current_value_93 = json_config['tools']['cocotb']['simulator_name'];
+        current_value_96 = json_config['tools']['cocotb']['simulator_name'];
     }
     catch(e){}
-    if ( current_value_93 === "icarus"){
+    if ( current_value_96 === "icarus"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.icarus;
     }
-    if ( current_value_93 === "verilator"){
+    if ( current_value_96 === "verilator"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.verilator;
     }
-    if ( current_value_93 === "vcs"){
+    if ( current_value_96 === "vcs"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.vcs;
     }
-    if ( current_value_93 === "riviera"){
+    if ( current_value_96 === "riviera"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.riviera;
     }
-    if ( current_value_93 === "activehdl"){
+    if ( current_value_96 === "activehdl"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.activehdl;
     }
-    if ( current_value_93 === "questa"){
+    if ( current_value_96 === "questa"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.questa;
     }
-    if ( current_value_93 === "modelsim"){
+    if ( current_value_96 === "modelsim"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.modelsim;
     }
-    if ( current_value_93 === "ius"){
+    if ( current_value_96 === "ius"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.ius;
     }
-    if ( current_value_93 === "xcelium"){
+    if ( current_value_96 === "xcelium"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.xcelium;
     }
-    if ( current_value_93 === "ghdl"){
+    if ( current_value_96 === "ghdl"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.ghdl;
     }
-    if ( current_value_93 === "cvc"){
+    if ( current_value_96 === "cvc"){
         default_config['tools']['cocotb']['simulator_name'] = e_tools_cocotb_simulator_name.cvc;
     }
             
     // tools -> cocotb -> compile_args
-    let current_value_94 = undefined;
-    try {
-        current_value_94 = json_config['tools']['cocotb']['compile_args'];
-    }
-    catch(e){}
-    if (typeof current_value_94 === 'string'){
-        default_config['tools']['cocotb']['compile_args'] = current_value_94;
-    }
-            
-    // tools -> cocotb -> run_args
-    let current_value_95 = undefined;
-    try {
-        current_value_95 = json_config['tools']['cocotb']['run_args'];
-    }
-    catch(e){}
-    if (typeof current_value_95 === 'string'){
-        default_config['tools']['cocotb']['run_args'] = current_value_95;
-    }
-            
-    // tools -> cocotb -> plusargs
-    let current_value_96 = undefined;
-    try {
-        current_value_96 = json_config['tools']['cocotb']['plusargs'];
-    }
-    catch(e){}
-    if (typeof current_value_96 === 'string'){
-        default_config['tools']['cocotb']['plusargs'] = current_value_96;
-    }
-            
-    // tools -> diamond -> installation_path
     let current_value_97 = undefined;
     try {
-        current_value_97 = json_config['tools']['diamond']['installation_path'];
+        current_value_97 = json_config['tools']['cocotb']['compile_args'];
     }
     catch(e){}
     if (typeof current_value_97 === 'string'){
-        default_config['tools']['diamond']['installation_path'] = current_value_97;
+        default_config['tools']['cocotb']['compile_args'] = current_value_97;
     }
             
-    // tools -> diamond -> part
+    // tools -> cocotb -> run_args
     let current_value_98 = undefined;
     try {
-        current_value_98 = json_config['tools']['diamond']['part'];
+        current_value_98 = json_config['tools']['cocotb']['run_args'];
     }
     catch(e){}
     if (typeof current_value_98 === 'string'){
-        default_config['tools']['diamond']['part'] = current_value_98;
+        default_config['tools']['cocotb']['run_args'] = current_value_98;
     }
             
-    // tools -> ghdl -> installation_path
+    // tools -> cocotb -> plusargs
     let current_value_99 = undefined;
     try {
-        current_value_99 = json_config['tools']['ghdl']['installation_path'];
+        current_value_99 = json_config['tools']['cocotb']['plusargs'];
     }
     catch(e){}
     if (typeof current_value_99 === 'string'){
-        default_config['tools']['ghdl']['installation_path'] = current_value_99;
+        default_config['tools']['cocotb']['plusargs'] = current_value_99;
+    }
+            
+    // tools -> diamond -> installation_path
+    let current_value_100 = undefined;
+    try {
+        current_value_100 = json_config['tools']['diamond']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_100 === 'string'){
+        default_config['tools']['diamond']['installation_path'] = current_value_100;
+    }
+            
+    // tools -> diamond -> part
+    let current_value_101 = undefined;
+    try {
+        current_value_101 = json_config['tools']['diamond']['part'];
+    }
+    catch(e){}
+    if (typeof current_value_101 === 'string'){
+        default_config['tools']['diamond']['part'] = current_value_101;
+    }
+            
+    // tools -> ghdl -> installation_path
+    let current_value_102 = undefined;
+    try {
+        current_value_102 = json_config['tools']['ghdl']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_102 === 'string'){
+        default_config['tools']['ghdl']['installation_path'] = current_value_102;
     }
             
     // tools -> ghdl -> vhdl_standard
-    let current_value_100 = undefined;
+    let current_value_103 = undefined;
     try {
-        current_value_100 = json_config['tools']['ghdl']['vhdl_standard'];
+        current_value_103 = json_config['tools']['ghdl']['vhdl_standard'];
     }
     catch(e){}
-    if ( current_value_100 === "auto"){
+    if ( current_value_103 === "auto"){
         default_config['tools']['ghdl']['vhdl_standard'] = e_tools_ghdl_vhdl_standard.auto;
     }
-    if ( current_value_100 === "vhdl87"){
+    if ( current_value_103 === "vhdl87"){
         default_config['tools']['ghdl']['vhdl_standard'] = e_tools_ghdl_vhdl_standard.vhdl87;
     }
-    if ( current_value_100 === "vhdl93"){
+    if ( current_value_103 === "vhdl93"){
         default_config['tools']['ghdl']['vhdl_standard'] = e_tools_ghdl_vhdl_standard.vhdl93;
     }
-    if ( current_value_100 === "vhdl02"){
+    if ( current_value_103 === "vhdl02"){
         default_config['tools']['ghdl']['vhdl_standard'] = e_tools_ghdl_vhdl_standard.vhdl02;
     }
-    if ( current_value_100 === "vhdl08"){
+    if ( current_value_103 === "vhdl08"){
         default_config['tools']['ghdl']['vhdl_standard'] = e_tools_ghdl_vhdl_standard.vhdl08;
     }
-    if ( current_value_100 === "vhdl19"){
+    if ( current_value_103 === "vhdl19"){
         default_config['tools']['ghdl']['vhdl_standard'] = e_tools_ghdl_vhdl_standard.vhdl19;
     }
             
     // tools -> ghdl -> ieee_library
-    let current_value_101 = undefined;
+    let current_value_104 = undefined;
     try {
-        current_value_101 = json_config['tools']['ghdl']['ieee_library'];
+        current_value_104 = json_config['tools']['ghdl']['ieee_library'];
     }
     catch(e){}
-    if ( current_value_101 === "standard"){
+    if ( current_value_104 === "standard"){
         default_config['tools']['ghdl']['ieee_library'] = e_tools_ghdl_ieee_library.standard;
     }
-    if ( current_value_101 === "synopsys"){
+    if ( current_value_104 === "synopsys"){
         default_config['tools']['ghdl']['ieee_library'] = e_tools_ghdl_ieee_library.synopsys;
     }
             
     // tools -> ghdl -> relaxed_parsing
-    let current_value_102 = undefined;
+    let current_value_105 = undefined;
     try {
-        current_value_102 = json_config['tools']['ghdl']['relaxed_parsing'];
+        current_value_105 = json_config['tools']['ghdl']['relaxed_parsing'];
     }
     catch(e){}
-    if (current_value_102 === true || current_value_102 === false){
-        default_config['tools']['ghdl']['relaxed_parsing'] = current_value_102;
+    if (current_value_105 === true || current_value_105 === false){
+        default_config['tools']['ghdl']['relaxed_parsing'] = current_value_105;
     }
             
     // tools -> ghdl -> unicode_support
-    let current_value_103 = undefined;
+    let current_value_106 = undefined;
     try {
-        current_value_103 = json_config['tools']['ghdl']['unicode_support'];
+        current_value_106 = json_config['tools']['ghdl']['unicode_support'];
     }
     catch(e){}
-    if (current_value_103 === true || current_value_103 === false){
-        default_config['tools']['ghdl']['unicode_support'] = current_value_103;
+    if (current_value_106 === true || current_value_106 === false){
+        default_config['tools']['ghdl']['unicode_support'] = current_value_106;
     }
             
     // tools -> ghdl -> psl_enabled
-    let current_value_104 = undefined;
+    let current_value_107 = undefined;
     try {
-        current_value_104 = json_config['tools']['ghdl']['psl_enabled'];
+        current_value_107 = json_config['tools']['ghdl']['psl_enabled'];
     }
     catch(e){}
-    if (current_value_104 === true || current_value_104 === false){
-        default_config['tools']['ghdl']['psl_enabled'] = current_value_104;
+    if (current_value_107 === true || current_value_107 === false){
+        default_config['tools']['ghdl']['psl_enabled'] = current_value_107;
     }
             
     // tools -> ghdl -> work_library
-    let current_value_105 = undefined;
+    let current_value_108 = undefined;
     try {
-        current_value_105 = json_config['tools']['ghdl']['work_library'];
+        current_value_108 = json_config['tools']['ghdl']['work_library'];
     }
     catch(e){}
-    if (typeof current_value_105 === 'string'){
-        default_config['tools']['ghdl']['work_library'] = current_value_105;
+    if (typeof current_value_108 === 'string'){
+        default_config['tools']['ghdl']['work_library'] = current_value_108;
     }
             
     // tools -> ghdl -> library_paths
-    let current_value_106 = undefined;
-    try {
-        current_value_106 = json_config['tools']['ghdl']['library_paths'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_106)){
-        default_config['tools']['ghdl']['library_paths'] = current_value_106;
-    }
-            
-    // tools -> ghdl -> check_syntax_options
-    let current_value_107 = undefined;
-    try {
-        current_value_107 = json_config['tools']['ghdl']['check_syntax_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_107)){
-        default_config['tools']['ghdl']['check_syntax_options'] = current_value_107;
-    }
-            
-    // tools -> ghdl -> analyze_options
-    let current_value_108 = undefined;
-    try {
-        current_value_108 = json_config['tools']['ghdl']['analyze_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_108)){
-        default_config['tools']['ghdl']['analyze_options'] = current_value_108;
-    }
-            
-    // tools -> ghdl -> elaborate_options
     let current_value_109 = undefined;
     try {
-        current_value_109 = json_config['tools']['ghdl']['elaborate_options'];
+        current_value_109 = json_config['tools']['ghdl']['library_paths'];
     }
     catch(e){}
     if (Array.isArray(current_value_109)){
-        default_config['tools']['ghdl']['elaborate_options'] = current_value_109;
+        default_config['tools']['ghdl']['library_paths'] = current_value_109;
     }
             
-    // tools -> ghdl -> run_options
+    // tools -> ghdl -> check_syntax_options
     let current_value_110 = undefined;
     try {
-        current_value_110 = json_config['tools']['ghdl']['run_options'];
+        current_value_110 = json_config['tools']['ghdl']['check_syntax_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_110)){
-        default_config['tools']['ghdl']['run_options'] = current_value_110;
+        default_config['tools']['ghdl']['check_syntax_options'] = current_value_110;
     }
             
-    // tools -> ghdl -> synthesis_options
+    // tools -> ghdl -> analyze_options
     let current_value_111 = undefined;
     try {
-        current_value_111 = json_config['tools']['ghdl']['synthesis_options'];
+        current_value_111 = json_config['tools']['ghdl']['analyze_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_111)){
-        default_config['tools']['ghdl']['synthesis_options'] = current_value_111;
+        default_config['tools']['ghdl']['analyze_options'] = current_value_111;
     }
             
-    // tools -> ghdl -> extra_flags
+    // tools -> ghdl -> elaborate_options
     let current_value_112 = undefined;
     try {
-        current_value_112 = json_config['tools']['ghdl']['extra_flags'];
+        current_value_112 = json_config['tools']['ghdl']['elaborate_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_112)){
-        default_config['tools']['ghdl']['extra_flags'] = current_value_112;
+        default_config['tools']['ghdl']['elaborate_options'] = current_value_112;
+    }
+            
+    // tools -> ghdl -> run_options
+    let current_value_113 = undefined;
+    try {
+        current_value_113 = json_config['tools']['ghdl']['run_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_113)){
+        default_config['tools']['ghdl']['run_options'] = current_value_113;
+    }
+            
+    // tools -> ghdl -> synthesis_options
+    let current_value_114 = undefined;
+    try {
+        current_value_114 = json_config['tools']['ghdl']['synthesis_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_114)){
+        default_config['tools']['ghdl']['synthesis_options'] = current_value_114;
+    }
+            
+    // tools -> ghdl -> extra_flags
+    let current_value_115 = undefined;
+    try {
+        current_value_115 = json_config['tools']['ghdl']['extra_flags'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_115)){
+        default_config['tools']['ghdl']['extra_flags'] = current_value_115;
     }
             
     // tools -> ghdl -> relaxed_rules
-    let current_value_113 = undefined;
+    let current_value_116 = undefined;
     try {
-        current_value_113 = json_config['tools']['ghdl']['relaxed_rules'];
+        current_value_116 = json_config['tools']['ghdl']['relaxed_rules'];
     }
     catch(e){}
-    if (current_value_113 === true || current_value_113 === false){
-        default_config['tools']['ghdl']['relaxed_rules'] = current_value_113;
+    if (current_value_116 === true || current_value_116 === false){
+        default_config['tools']['ghdl']['relaxed_rules'] = current_value_116;
     }
             
     // tools -> ghdl -> bind_checks
-    let current_value_114 = undefined;
+    let current_value_117 = undefined;
     try {
-        current_value_114 = json_config['tools']['ghdl']['bind_checks'];
+        current_value_117 = json_config['tools']['ghdl']['bind_checks'];
     }
     catch(e){}
-    if (current_value_114 === true || current_value_114 === false){
-        default_config['tools']['ghdl']['bind_checks'] = current_value_114;
+    if (current_value_117 === true || current_value_117 === false){
+        default_config['tools']['ghdl']['bind_checks'] = current_value_117;
     }
             
     // tools -> ghdl -> vital_checks
-    let current_value_115 = undefined;
+    let current_value_118 = undefined;
     try {
-        current_value_115 = json_config['tools']['ghdl']['vital_checks'];
+        current_value_118 = json_config['tools']['ghdl']['vital_checks'];
     }
     catch(e){}
-    if (current_value_115 === true || current_value_115 === false){
-        default_config['tools']['ghdl']['vital_checks'] = current_value_115;
+    if (current_value_118 === true || current_value_118 === false){
+        default_config['tools']['ghdl']['vital_checks'] = current_value_118;
     }
             
     // tools -> ghdl -> simulation_time
-    let current_value_116 = undefined;
+    let current_value_119 = undefined;
     try {
-        current_value_116 = json_config['tools']['ghdl']['simulation_time'];
+        current_value_119 = json_config['tools']['ghdl']['simulation_time'];
     }
     catch(e){}
-    if (typeof current_value_116 === 'string'){
-        default_config['tools']['ghdl']['simulation_time'] = current_value_116;
+    if (typeof current_value_119 === 'string'){
+        default_config['tools']['ghdl']['simulation_time'] = current_value_119;
     }
             
     // tools -> ghdl -> resolution_limit
-    let current_value_117 = undefined;
+    let current_value_120 = undefined;
     try {
-        current_value_117 = json_config['tools']['ghdl']['resolution_limit'];
+        current_value_120 = json_config['tools']['ghdl']['resolution_limit'];
     }
     catch(e){}
-    if (typeof current_value_117 === 'string'){
-        default_config['tools']['ghdl']['resolution_limit'] = current_value_117;
+    if (typeof current_value_120 === 'string'){
+        default_config['tools']['ghdl']['resolution_limit'] = current_value_120;
     }
             
     // tools -> ghdl -> stack_size
-    let current_value_118 = undefined;
+    let current_value_121 = undefined;
     try {
-        current_value_118 = json_config['tools']['ghdl']['stack_size'];
+        current_value_121 = json_config['tools']['ghdl']['stack_size'];
     }
     catch(e){}
-    if (typeof current_value_118 === 'string'){
-        default_config['tools']['ghdl']['stack_size'] = current_value_118;
+    if (typeof current_value_121 === 'string'){
+        default_config['tools']['ghdl']['stack_size'] = current_value_121;
     }
             
     // tools -> ghdl -> stop_delta_cycles
-    let current_value_119 = undefined;
+    let current_value_122 = undefined;
     try {
-        current_value_119 = json_config['tools']['ghdl']['stop_delta_cycles'];
+        current_value_122 = json_config['tools']['ghdl']['stop_delta_cycles'];
     }
     catch(e){}
-    if (typeof current_value_119 === 'number'){
-        default_config['tools']['ghdl']['stop_delta_cycles'] = current_value_119;
+    if (typeof current_value_122 === 'number'){
+        default_config['tools']['ghdl']['stop_delta_cycles'] = current_value_122;
     }
             
     // tools -> ghdl -> waveform_enabled
-    let current_value_120 = undefined;
+    let current_value_123 = undefined;
     try {
-        current_value_120 = json_config['tools']['ghdl']['waveform_enabled'];
+        current_value_123 = json_config['tools']['ghdl']['waveform_enabled'];
     }
     catch(e){}
-    if (current_value_120 === true || current_value_120 === false){
-        default_config['tools']['ghdl']['waveform_enabled'] = current_value_120;
+    if (current_value_123 === true || current_value_123 === false){
+        default_config['tools']['ghdl']['waveform_enabled'] = current_value_123;
     }
             
     // tools -> ghdl -> waveform_format
-    let current_value_121 = undefined;
+    let current_value_124 = undefined;
     try {
-        current_value_121 = json_config['tools']['ghdl']['waveform_format'];
+        current_value_124 = json_config['tools']['ghdl']['waveform_format'];
     }
     catch(e){}
-    if ( current_value_121 === "vcd"){
+    if ( current_value_124 === "vcd"){
         default_config['tools']['ghdl']['waveform_format'] = e_tools_ghdl_waveform_format.vcd;
     }
-    if ( current_value_121 === "ghw"){
+    if ( current_value_124 === "ghw"){
         default_config['tools']['ghdl']['waveform_format'] = e_tools_ghdl_waveform_format.ghw;
     }
-    if ( current_value_121 === "fst"){
+    if ( current_value_124 === "fst"){
         default_config['tools']['ghdl']['waveform_format'] = e_tools_ghdl_waveform_format.fst;
     }
             
     // tools -> ghdl -> waveform_options
-    let current_value_122 = undefined;
+    let current_value_125 = undefined;
     try {
-        current_value_122 = json_config['tools']['ghdl']['waveform_options'];
+        current_value_125 = json_config['tools']['ghdl']['waveform_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_122)){
-        default_config['tools']['ghdl']['waveform_options'] = current_value_122;
+    if (Array.isArray(current_value_125)){
+        default_config['tools']['ghdl']['waveform_options'] = current_value_125;
     }
             
     // tools -> ghdl -> wave_start_time
-    let current_value_123 = undefined;
-    try {
-        current_value_123 = json_config['tools']['ghdl']['wave_start_time'];
-    }
-    catch(e){}
-    if (typeof current_value_123 === 'string'){
-        default_config['tools']['ghdl']['wave_start_time'] = current_value_123;
-    }
-            
-    // tools -> ghdl -> vcd_4states
-    let current_value_124 = undefined;
-    try {
-        current_value_124 = json_config['tools']['ghdl']['vcd_4states'];
-    }
-    catch(e){}
-    if (current_value_124 === true || current_value_124 === false){
-        default_config['tools']['ghdl']['vcd_4states'] = current_value_124;
-    }
-            
-    // tools -> ghdl -> vcd_nodate
-    let current_value_125 = undefined;
-    try {
-        current_value_125 = json_config['tools']['ghdl']['vcd_nodate'];
-    }
-    catch(e){}
-    if (current_value_125 === true || current_value_125 === false){
-        default_config['tools']['ghdl']['vcd_nodate'] = current_value_125;
-    }
-            
-    // tools -> ghdl -> read_wave_opt
     let current_value_126 = undefined;
     try {
-        current_value_126 = json_config['tools']['ghdl']['read_wave_opt'];
+        current_value_126 = json_config['tools']['ghdl']['wave_start_time'];
     }
     catch(e){}
     if (typeof current_value_126 === 'string'){
-        default_config['tools']['ghdl']['read_wave_opt'] = current_value_126;
+        default_config['tools']['ghdl']['wave_start_time'] = current_value_126;
+    }
+            
+    // tools -> ghdl -> vcd_4states
+    let current_value_127 = undefined;
+    try {
+        current_value_127 = json_config['tools']['ghdl']['vcd_4states'];
+    }
+    catch(e){}
+    if (current_value_127 === true || current_value_127 === false){
+        default_config['tools']['ghdl']['vcd_4states'] = current_value_127;
+    }
+            
+    // tools -> ghdl -> vcd_nodate
+    let current_value_128 = undefined;
+    try {
+        current_value_128 = json_config['tools']['ghdl']['vcd_nodate'];
+    }
+    catch(e){}
+    if (current_value_128 === true || current_value_128 === false){
+        default_config['tools']['ghdl']['vcd_nodate'] = current_value_128;
+    }
+            
+    // tools -> ghdl -> read_wave_opt
+    let current_value_129 = undefined;
+    try {
+        current_value_129 = json_config['tools']['ghdl']['read_wave_opt'];
+    }
+    catch(e){}
+    if (typeof current_value_129 === 'string'){
+        default_config['tools']['ghdl']['read_wave_opt'] = current_value_129;
     }
             
     // tools -> ghdl -> write_wave_opt
-    let current_value_127 = undefined;
+    let current_value_130 = undefined;
     try {
-        current_value_127 = json_config['tools']['ghdl']['write_wave_opt'];
+        current_value_130 = json_config['tools']['ghdl']['write_wave_opt'];
     }
     catch(e){}
-    if (typeof current_value_127 === 'string'){
-        default_config['tools']['ghdl']['write_wave_opt'] = current_value_127;
+    if (typeof current_value_130 === 'string'){
+        default_config['tools']['ghdl']['write_wave_opt'] = current_value_130;
     }
             
     // tools -> ghdl -> debug_level
-    let current_value_128 = undefined;
+    let current_value_131 = undefined;
     try {
-        current_value_128 = json_config['tools']['ghdl']['debug_level'];
+        current_value_131 = json_config['tools']['ghdl']['debug_level'];
     }
     catch(e){}
-    if ( current_value_128 === "none"){
+    if ( current_value_131 === "none"){
         default_config['tools']['ghdl']['debug_level'] = e_tools_ghdl_debug_level.none;
     }
-    if ( current_value_128 === "minimal"){
+    if ( current_value_131 === "minimal"){
         default_config['tools']['ghdl']['debug_level'] = e_tools_ghdl_debug_level.minimal;
     }
-    if ( current_value_128 === "full"){
+    if ( current_value_131 === "full"){
         default_config['tools']['ghdl']['debug_level'] = e_tools_ghdl_debug_level.full;
     }
             
     // tools -> ghdl -> verbose
-    let current_value_129 = undefined;
+    let current_value_132 = undefined;
     try {
-        current_value_129 = json_config['tools']['ghdl']['verbose'];
+        current_value_132 = json_config['tools']['ghdl']['verbose'];
     }
     catch(e){}
-    if (current_value_129 === true || current_value_129 === false){
-        default_config['tools']['ghdl']['verbose'] = current_value_129;
+    if (current_value_132 === true || current_value_132 === false){
+        default_config['tools']['ghdl']['verbose'] = current_value_132;
     }
             
     // tools -> ghdl -> warnings_as_errors
-    let current_value_130 = undefined;
+    let current_value_133 = undefined;
     try {
-        current_value_130 = json_config['tools']['ghdl']['warnings_as_errors'];
+        current_value_133 = json_config['tools']['ghdl']['warnings_as_errors'];
     }
     catch(e){}
-    if (current_value_130 === true || current_value_130 === false){
-        default_config['tools']['ghdl']['warnings_as_errors'] = current_value_130;
+    if (current_value_133 === true || current_value_133 === false){
+        default_config['tools']['ghdl']['warnings_as_errors'] = current_value_133;
     }
             
     // tools -> ghdl -> suppress_warnings
-    let current_value_131 = undefined;
+    let current_value_134 = undefined;
     try {
-        current_value_131 = json_config['tools']['ghdl']['suppress_warnings'];
+        current_value_134 = json_config['tools']['ghdl']['suppress_warnings'];
     }
     catch(e){}
-    if (Array.isArray(current_value_131)){
-        default_config['tools']['ghdl']['suppress_warnings'] = current_value_131;
+    if (Array.isArray(current_value_134)){
+        default_config['tools']['ghdl']['suppress_warnings'] = current_value_134;
     }
             
     // tools -> ghdl -> assert_level
-    let current_value_132 = undefined;
+    let current_value_135 = undefined;
     try {
-        current_value_132 = json_config['tools']['ghdl']['assert_level'];
+        current_value_135 = json_config['tools']['ghdl']['assert_level'];
     }
     catch(e){}
-    if ( current_value_132 === "note"){
+    if ( current_value_135 === "note"){
         default_config['tools']['ghdl']['assert_level'] = e_tools_ghdl_assert_level.note;
     }
-    if ( current_value_132 === "warning"){
+    if ( current_value_135 === "warning"){
         default_config['tools']['ghdl']['assert_level'] = e_tools_ghdl_assert_level.warning;
     }
-    if ( current_value_132 === "error"){
+    if ( current_value_135 === "error"){
         default_config['tools']['ghdl']['assert_level'] = e_tools_ghdl_assert_level.error;
     }
-    if ( current_value_132 === "failure"){
+    if ( current_value_135 === "failure"){
         default_config['tools']['ghdl']['assert_level'] = e_tools_ghdl_assert_level.failure;
     }
-    if ( current_value_132 === "none"){
+    if ( current_value_135 === "none"){
         default_config['tools']['ghdl']['assert_level'] = e_tools_ghdl_assert_level.none;
     }
             
     // tools -> ghdl -> display_time
-    let current_value_133 = undefined;
+    let current_value_136 = undefined;
     try {
-        current_value_133 = json_config['tools']['ghdl']['display_time'];
+        current_value_136 = json_config['tools']['ghdl']['display_time'];
     }
     catch(e){}
-    if (current_value_133 === true || current_value_133 === false){
-        default_config['tools']['ghdl']['display_time'] = current_value_133;
+    if (current_value_136 === true || current_value_136 === false){
+        default_config['tools']['ghdl']['display_time'] = current_value_136;
     }
             
     // tools -> ghdl -> unbuffered_output
-    let current_value_134 = undefined;
+    let current_value_137 = undefined;
     try {
-        current_value_134 = json_config['tools']['ghdl']['unbuffered_output'];
+        current_value_137 = json_config['tools']['ghdl']['unbuffered_output'];
     }
     catch(e){}
-    if (current_value_134 === true || current_value_134 === false){
-        default_config['tools']['ghdl']['unbuffered_output'] = current_value_134;
+    if (current_value_137 === true || current_value_137 === false){
+        default_config['tools']['ghdl']['unbuffered_output'] = current_value_137;
     }
             
     // tools -> ghdl -> max_stack_alloc
-    let current_value_135 = undefined;
+    let current_value_138 = undefined;
     try {
-        current_value_135 = json_config['tools']['ghdl']['max_stack_alloc'];
+        current_value_138 = json_config['tools']['ghdl']['max_stack_alloc'];
     }
     catch(e){}
-    if (typeof current_value_135 === 'number'){
-        default_config['tools']['ghdl']['max_stack_alloc'] = current_value_135;
+    if (typeof current_value_138 === 'number'){
+        default_config['tools']['ghdl']['max_stack_alloc'] = current_value_138;
     }
             
     // tools -> ghdl -> backtrace_severity
-    let current_value_136 = undefined;
+    let current_value_139 = undefined;
     try {
-        current_value_136 = json_config['tools']['ghdl']['backtrace_severity'];
+        current_value_139 = json_config['tools']['ghdl']['backtrace_severity'];
     }
     catch(e){}
-    if ( current_value_136 === "note"){
+    if ( current_value_139 === "note"){
         default_config['tools']['ghdl']['backtrace_severity'] = e_tools_ghdl_backtrace_severity.note;
     }
-    if ( current_value_136 === "warning"){
+    if ( current_value_139 === "warning"){
         default_config['tools']['ghdl']['backtrace_severity'] = e_tools_ghdl_backtrace_severity.warning;
     }
-    if ( current_value_136 === "error"){
+    if ( current_value_139 === "error"){
         default_config['tools']['ghdl']['backtrace_severity'] = e_tools_ghdl_backtrace_severity.error;
     }
-    if ( current_value_136 === "failure"){
+    if ( current_value_139 === "failure"){
         default_config['tools']['ghdl']['backtrace_severity'] = e_tools_ghdl_backtrace_severity.failure;
     }
-    if ( current_value_136 === "none"){
+    if ( current_value_139 === "none"){
         default_config['tools']['ghdl']['backtrace_severity'] = e_tools_ghdl_backtrace_severity.none;
     }
             
     // tools -> ghdl -> ieee_asserts
-    let current_value_137 = undefined;
+    let current_value_140 = undefined;
     try {
-        current_value_137 = json_config['tools']['ghdl']['ieee_asserts'];
+        current_value_140 = json_config['tools']['ghdl']['ieee_asserts'];
     }
     catch(e){}
-    if ( current_value_137 === "enable"){
+    if ( current_value_140 === "enable"){
         default_config['tools']['ghdl']['ieee_asserts'] = e_tools_ghdl_ieee_asserts.enable;
     }
-    if ( current_value_137 === "disable"){
+    if ( current_value_140 === "disable"){
         default_config['tools']['ghdl']['ieee_asserts'] = e_tools_ghdl_ieee_asserts.disable;
     }
-    if ( current_value_137 === "disable-at-0"){
+    if ( current_value_140 === "disable-at-0"){
         default_config['tools']['ghdl']['ieee_asserts'] = e_tools_ghdl_ieee_asserts.disable_at_0;
     }
             
     // tools -> ghdl -> asserts_policy
-    let current_value_138 = undefined;
+    let current_value_141 = undefined;
     try {
-        current_value_138 = json_config['tools']['ghdl']['asserts_policy'];
+        current_value_141 = json_config['tools']['ghdl']['asserts_policy'];
     }
     catch(e){}
-    if ( current_value_138 === "enable"){
+    if ( current_value_141 === "enable"){
         default_config['tools']['ghdl']['asserts_policy'] = e_tools_ghdl_asserts_policy.enable;
     }
-    if ( current_value_138 === "disable"){
+    if ( current_value_141 === "disable"){
         default_config['tools']['ghdl']['asserts_policy'] = e_tools_ghdl_asserts_policy.disable;
     }
-    if ( current_value_138 === "disable-at-0"){
+    if ( current_value_141 === "disable-at-0"){
         default_config['tools']['ghdl']['asserts_policy'] = e_tools_ghdl_asserts_policy.disable_at_0;
     }
             
     // tools -> ghdl -> sdf_file
-    let current_value_139 = undefined;
-    try {
-        current_value_139 = json_config['tools']['ghdl']['sdf_file'];
-    }
-    catch(e){}
-    if (typeof current_value_139 === 'string'){
-        default_config['tools']['ghdl']['sdf_file'] = current_value_139;
-    }
-            
-    // tools -> ghdl -> vpi_modules
-    let current_value_140 = undefined;
-    try {
-        current_value_140 = json_config['tools']['ghdl']['vpi_modules'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_140)){
-        default_config['tools']['ghdl']['vpi_modules'] = current_value_140;
-    }
-            
-    // tools -> ghdl -> vhpi_modules
-    let current_value_141 = undefined;
-    try {
-        current_value_141 = json_config['tools']['ghdl']['vhpi_modules'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_141)){
-        default_config['tools']['ghdl']['vhpi_modules'] = current_value_141;
-    }
-            
-    // tools -> ghdl -> vpi_trace_file
     let current_value_142 = undefined;
     try {
-        current_value_142 = json_config['tools']['ghdl']['vpi_trace_file'];
+        current_value_142 = json_config['tools']['ghdl']['sdf_file'];
     }
     catch(e){}
     if (typeof current_value_142 === 'string'){
-        default_config['tools']['ghdl']['vpi_trace_file'] = current_value_142;
+        default_config['tools']['ghdl']['sdf_file'] = current_value_142;
+    }
+            
+    // tools -> ghdl -> vpi_modules
+    let current_value_143 = undefined;
+    try {
+        current_value_143 = json_config['tools']['ghdl']['vpi_modules'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_143)){
+        default_config['tools']['ghdl']['vpi_modules'] = current_value_143;
+    }
+            
+    // tools -> ghdl -> vhpi_modules
+    let current_value_144 = undefined;
+    try {
+        current_value_144 = json_config['tools']['ghdl']['vhpi_modules'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_144)){
+        default_config['tools']['ghdl']['vhpi_modules'] = current_value_144;
+    }
+            
+    // tools -> ghdl -> vpi_trace_file
+    let current_value_145 = undefined;
+    try {
+        current_value_145 = json_config['tools']['ghdl']['vpi_trace_file'];
+    }
+    catch(e){}
+    if (typeof current_value_145 === 'string'){
+        default_config['tools']['ghdl']['vpi_trace_file'] = current_value_145;
     }
             
     // tools -> ghdl -> vhpi_trace_file
-    let current_value_143 = undefined;
+    let current_value_146 = undefined;
     try {
-        current_value_143 = json_config['tools']['ghdl']['vhpi_trace_file'];
+        current_value_146 = json_config['tools']['ghdl']['vhpi_trace_file'];
     }
     catch(e){}
-    if (typeof current_value_143 === 'string'){
-        default_config['tools']['ghdl']['vhpi_trace_file'] = current_value_143;
+    if (typeof current_value_146 === 'string'){
+        default_config['tools']['ghdl']['vhpi_trace_file'] = current_value_146;
     }
             
     // tools -> ghdl -> psl_report_file
-    let current_value_144 = undefined;
+    let current_value_147 = undefined;
     try {
-        current_value_144 = json_config['tools']['ghdl']['psl_report_file'];
+        current_value_147 = json_config['tools']['ghdl']['psl_report_file'];
     }
     catch(e){}
-    if (typeof current_value_144 === 'string'){
-        default_config['tools']['ghdl']['psl_report_file'] = current_value_144;
+    if (typeof current_value_147 === 'string'){
+        default_config['tools']['ghdl']['psl_report_file'] = current_value_147;
     }
             
     // tools -> ghdl -> psl_report_uncovered
-    let current_value_145 = undefined;
+    let current_value_148 = undefined;
     try {
-        current_value_145 = json_config['tools']['ghdl']['psl_report_uncovered'];
+        current_value_148 = json_config['tools']['ghdl']['psl_report_uncovered'];
     }
     catch(e){}
-    if (current_value_145 === true || current_value_145 === false){
-        default_config['tools']['ghdl']['psl_report_uncovered'] = current_value_145;
+    if (current_value_148 === true || current_value_148 === false){
+        default_config['tools']['ghdl']['psl_report_uncovered'] = current_value_148;
     }
             
     // tools -> ghdl -> disp_tree
-    let current_value_146 = undefined;
+    let current_value_149 = undefined;
     try {
-        current_value_146 = json_config['tools']['ghdl']['disp_tree'];
+        current_value_149 = json_config['tools']['ghdl']['disp_tree'];
     }
     catch(e){}
-    if ( current_value_146 === "none"){
+    if ( current_value_149 === "none"){
         default_config['tools']['ghdl']['disp_tree'] = e_tools_ghdl_disp_tree.none;
     }
-    if ( current_value_146 === "inst"){
+    if ( current_value_149 === "inst"){
         default_config['tools']['ghdl']['disp_tree'] = e_tools_ghdl_disp_tree.inst;
     }
-    if ( current_value_146 === "proc"){
+    if ( current_value_149 === "proc"){
         default_config['tools']['ghdl']['disp_tree'] = e_tools_ghdl_disp_tree.proc;
     }
-    if ( current_value_146 === "port"){
+    if ( current_value_149 === "port"){
         default_config['tools']['ghdl']['disp_tree'] = e_tools_ghdl_disp_tree.port;
     }
             
     // tools -> ghdl -> no_run
-    let current_value_147 = undefined;
+    let current_value_150 = undefined;
     try {
-        current_value_147 = json_config['tools']['ghdl']['no_run'];
+        current_value_150 = json_config['tools']['ghdl']['no_run'];
     }
     catch(e){}
-    if (current_value_147 === true || current_value_147 === false){
-        default_config['tools']['ghdl']['no_run'] = current_value_147;
+    if (current_value_150 === true || current_value_150 === false){
+        default_config['tools']['ghdl']['no_run'] = current_value_150;
     }
             
     // tools -> icarus -> installation_path
-    let current_value_148 = undefined;
-    try {
-        current_value_148 = json_config['tools']['icarus']['installation_path'];
-    }
-    catch(e){}
-    if (typeof current_value_148 === 'string'){
-        default_config['tools']['icarus']['installation_path'] = current_value_148;
-    }
-            
-    // tools -> icarus -> timescale
-    let current_value_149 = undefined;
-    try {
-        current_value_149 = json_config['tools']['icarus']['timescale'];
-    }
-    catch(e){}
-    if (typeof current_value_149 === 'string'){
-        default_config['tools']['icarus']['timescale'] = current_value_149;
-    }
-            
-    // tools -> icarus -> iverilog_options
-    let current_value_150 = undefined;
-    try {
-        current_value_150 = json_config['tools']['icarus']['iverilog_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_150)){
-        default_config['tools']['icarus']['iverilog_options'] = current_value_150;
-    }
-            
-    // tools -> icestorm -> installation_path
     let current_value_151 = undefined;
     try {
-        current_value_151 = json_config['tools']['icestorm']['installation_path'];
+        current_value_151 = json_config['tools']['icarus']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_151 === 'string'){
-        default_config['tools']['icestorm']['installation_path'] = current_value_151;
+        default_config['tools']['icarus']['installation_path'] = current_value_151;
+    }
+            
+    // tools -> icarus -> timescale
+    let current_value_152 = undefined;
+    try {
+        current_value_152 = json_config['tools']['icarus']['timescale'];
+    }
+    catch(e){}
+    if (typeof current_value_152 === 'string'){
+        default_config['tools']['icarus']['timescale'] = current_value_152;
+    }
+            
+    // tools -> icarus -> iverilog_options
+    let current_value_153 = undefined;
+    try {
+        current_value_153 = json_config['tools']['icarus']['iverilog_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_153)){
+        default_config['tools']['icarus']['iverilog_options'] = current_value_153;
+    }
+            
+    // tools -> icestorm -> installation_path
+    let current_value_154 = undefined;
+    try {
+        current_value_154 = json_config['tools']['icestorm']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_154 === 'string'){
+        default_config['tools']['icestorm']['installation_path'] = current_value_154;
     }
             
     // tools -> icestorm -> pnr
-    let current_value_152 = undefined;
+    let current_value_155 = undefined;
     try {
-        current_value_152 = json_config['tools']['icestorm']['pnr'];
+        current_value_155 = json_config['tools']['icestorm']['pnr'];
     }
     catch(e){}
-    if ( current_value_152 === "arachne"){
+    if ( current_value_155 === "arachne"){
         default_config['tools']['icestorm']['pnr'] = e_tools_icestorm_pnr.arachne;
     }
-    if ( current_value_152 === "next"){
+    if ( current_value_155 === "next"){
         default_config['tools']['icestorm']['pnr'] = e_tools_icestorm_pnr.next;
     }
-    if ( current_value_152 === "none"){
+    if ( current_value_155 === "none"){
         default_config['tools']['icestorm']['pnr'] = e_tools_icestorm_pnr.none;
     }
             
     // tools -> icestorm -> arch
-    let current_value_153 = undefined;
+    let current_value_156 = undefined;
     try {
-        current_value_153 = json_config['tools']['icestorm']['arch'];
+        current_value_156 = json_config['tools']['icestorm']['arch'];
     }
     catch(e){}
-    if ( current_value_153 === "xilinx"){
+    if ( current_value_156 === "xilinx"){
         default_config['tools']['icestorm']['arch'] = e_tools_icestorm_arch.xilinx;
     }
-    if ( current_value_153 === "ice40"){
+    if ( current_value_156 === "ice40"){
         default_config['tools']['icestorm']['arch'] = e_tools_icestorm_arch.ice40;
     }
-    if ( current_value_153 === "ecp5"){
+    if ( current_value_156 === "ecp5"){
         default_config['tools']['icestorm']['arch'] = e_tools_icestorm_arch.ecp5;
     }
             
     // tools -> icestorm -> output_format
-    let current_value_154 = undefined;
+    let current_value_157 = undefined;
     try {
-        current_value_154 = json_config['tools']['icestorm']['output_format'];
+        current_value_157 = json_config['tools']['icestorm']['output_format'];
     }
     catch(e){}
-    if ( current_value_154 === "json"){
+    if ( current_value_157 === "json"){
         default_config['tools']['icestorm']['output_format'] = e_tools_icestorm_output_format.json;
     }
-    if ( current_value_154 === "edif"){
+    if ( current_value_157 === "edif"){
         default_config['tools']['icestorm']['output_format'] = e_tools_icestorm_output_format.edif;
     }
-    if ( current_value_154 === "blif"){
+    if ( current_value_157 === "blif"){
         default_config['tools']['icestorm']['output_format'] = e_tools_icestorm_output_format.blif;
     }
             
     // tools -> icestorm -> yosys_as_subtool
-    let current_value_155 = undefined;
+    let current_value_158 = undefined;
     try {
-        current_value_155 = json_config['tools']['icestorm']['yosys_as_subtool'];
+        current_value_158 = json_config['tools']['icestorm']['yosys_as_subtool'];
     }
     catch(e){}
-    if (current_value_155 === true || current_value_155 === false){
-        default_config['tools']['icestorm']['yosys_as_subtool'] = current_value_155;
+    if (current_value_158 === true || current_value_158 === false){
+        default_config['tools']['icestorm']['yosys_as_subtool'] = current_value_158;
     }
             
     // tools -> icestorm -> makefile_name
-    let current_value_156 = undefined;
+    let current_value_159 = undefined;
     try {
-        current_value_156 = json_config['tools']['icestorm']['makefile_name'];
+        current_value_159 = json_config['tools']['icestorm']['makefile_name'];
     }
     catch(e){}
-    if (typeof current_value_156 === 'string'){
-        default_config['tools']['icestorm']['makefile_name'] = current_value_156;
+    if (typeof current_value_159 === 'string'){
+        default_config['tools']['icestorm']['makefile_name'] = current_value_159;
     }
             
     // tools -> icestorm -> arachne_pnr_options
-    let current_value_157 = undefined;
+    let current_value_160 = undefined;
     try {
-        current_value_157 = json_config['tools']['icestorm']['arachne_pnr_options'];
+        current_value_160 = json_config['tools']['icestorm']['arachne_pnr_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_157)){
-        default_config['tools']['icestorm']['arachne_pnr_options'] = current_value_157;
+    if (Array.isArray(current_value_160)){
+        default_config['tools']['icestorm']['arachne_pnr_options'] = current_value_160;
     }
             
     // tools -> icestorm -> nextpnr_options
-    let current_value_158 = undefined;
+    let current_value_161 = undefined;
     try {
-        current_value_158 = json_config['tools']['icestorm']['nextpnr_options'];
+        current_value_161 = json_config['tools']['icestorm']['nextpnr_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_158)){
-        default_config['tools']['icestorm']['nextpnr_options'] = current_value_158;
+    if (Array.isArray(current_value_161)){
+        default_config['tools']['icestorm']['nextpnr_options'] = current_value_161;
     }
             
     // tools -> icestorm -> yosys_synth_options
-    let current_value_159 = undefined;
+    let current_value_162 = undefined;
     try {
-        current_value_159 = json_config['tools']['icestorm']['yosys_synth_options'];
+        current_value_162 = json_config['tools']['icestorm']['yosys_synth_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_159)){
-        default_config['tools']['icestorm']['yosys_synth_options'] = current_value_159;
+    if (Array.isArray(current_value_162)){
+        default_config['tools']['icestorm']['yosys_synth_options'] = current_value_162;
     }
             
     // tools -> ise -> installation_path
-    let current_value_160 = undefined;
-    try {
-        current_value_160 = json_config['tools']['ise']['installation_path'];
-    }
-    catch(e){}
-    if (typeof current_value_160 === 'string'){
-        default_config['tools']['ise']['installation_path'] = current_value_160;
-    }
-            
-    // tools -> ise -> family
-    let current_value_161 = undefined;
-    try {
-        current_value_161 = json_config['tools']['ise']['family'];
-    }
-    catch(e){}
-    if (typeof current_value_161 === 'string'){
-        default_config['tools']['ise']['family'] = current_value_161;
-    }
-            
-    // tools -> ise -> device
-    let current_value_162 = undefined;
-    try {
-        current_value_162 = json_config['tools']['ise']['device'];
-    }
-    catch(e){}
-    if (typeof current_value_162 === 'string'){
-        default_config['tools']['ise']['device'] = current_value_162;
-    }
-            
-    // tools -> ise -> package
     let current_value_163 = undefined;
     try {
-        current_value_163 = json_config['tools']['ise']['package'];
+        current_value_163 = json_config['tools']['ise']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_163 === 'string'){
-        default_config['tools']['ise']['package'] = current_value_163;
+        default_config['tools']['ise']['installation_path'] = current_value_163;
     }
             
-    // tools -> ise -> speed
+    // tools -> ise -> family
     let current_value_164 = undefined;
     try {
-        current_value_164 = json_config['tools']['ise']['speed'];
+        current_value_164 = json_config['tools']['ise']['family'];
     }
     catch(e){}
     if (typeof current_value_164 === 'string'){
-        default_config['tools']['ise']['speed'] = current_value_164;
+        default_config['tools']['ise']['family'] = current_value_164;
     }
             
-    // tools -> isem -> installation_path
+    // tools -> ise -> device
     let current_value_165 = undefined;
     try {
-        current_value_165 = json_config['tools']['isem']['installation_path'];
+        current_value_165 = json_config['tools']['ise']['device'];
     }
     catch(e){}
     if (typeof current_value_165 === 'string'){
-        default_config['tools']['isem']['installation_path'] = current_value_165;
+        default_config['tools']['ise']['device'] = current_value_165;
     }
             
-    // tools -> isem -> fuse_options
+    // tools -> ise -> package
     let current_value_166 = undefined;
     try {
-        current_value_166 = json_config['tools']['isem']['fuse_options'];
+        current_value_166 = json_config['tools']['ise']['package'];
     }
     catch(e){}
-    if (Array.isArray(current_value_166)){
-        default_config['tools']['isem']['fuse_options'] = current_value_166;
+    if (typeof current_value_166 === 'string'){
+        default_config['tools']['ise']['package'] = current_value_166;
     }
             
-    // tools -> isem -> isim_options
+    // tools -> ise -> speed
     let current_value_167 = undefined;
     try {
-        current_value_167 = json_config['tools']['isem']['isim_options'];
+        current_value_167 = json_config['tools']['ise']['speed'];
     }
     catch(e){}
-    if (Array.isArray(current_value_167)){
-        default_config['tools']['isem']['isim_options'] = current_value_167;
+    if (typeof current_value_167 === 'string'){
+        default_config['tools']['ise']['speed'] = current_value_167;
     }
             
-    // tools -> modelsim -> installation_path
+    // tools -> isem -> installation_path
     let current_value_168 = undefined;
     try {
-        current_value_168 = json_config['tools']['modelsim']['installation_path'];
+        current_value_168 = json_config['tools']['isem']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_168 === 'string'){
-        default_config['tools']['modelsim']['installation_path'] = current_value_168;
+        default_config['tools']['isem']['installation_path'] = current_value_168;
     }
             
-    // tools -> modelsim -> vcom_options
+    // tools -> isem -> fuse_options
     let current_value_169 = undefined;
     try {
-        current_value_169 = json_config['tools']['modelsim']['vcom_options'];
+        current_value_169 = json_config['tools']['isem']['fuse_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_169)){
-        default_config['tools']['modelsim']['vcom_options'] = current_value_169;
+        default_config['tools']['isem']['fuse_options'] = current_value_169;
     }
             
-    // tools -> modelsim -> vlog_options
+    // tools -> isem -> isim_options
     let current_value_170 = undefined;
     try {
-        current_value_170 = json_config['tools']['modelsim']['vlog_options'];
+        current_value_170 = json_config['tools']['isem']['isim_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_170)){
-        default_config['tools']['modelsim']['vlog_options'] = current_value_170;
+        default_config['tools']['isem']['isim_options'] = current_value_170;
     }
             
-    // tools -> modelsim -> vsim_options
+    // tools -> modelsim -> installation_path
     let current_value_171 = undefined;
     try {
-        current_value_171 = json_config['tools']['modelsim']['vsim_options'];
+        current_value_171 = json_config['tools']['modelsim']['installation_path'];
     }
     catch(e){}
-    if (Array.isArray(current_value_171)){
-        default_config['tools']['modelsim']['vsim_options'] = current_value_171;
+    if (typeof current_value_171 === 'string'){
+        default_config['tools']['modelsim']['installation_path'] = current_value_171;
     }
             
-    // tools -> morty -> installation_path
+    // tools -> modelsim -> vcom_options
     let current_value_172 = undefined;
     try {
-        current_value_172 = json_config['tools']['morty']['installation_path'];
+        current_value_172 = json_config['tools']['modelsim']['vcom_options'];
     }
     catch(e){}
-    if (typeof current_value_172 === 'string'){
-        default_config['tools']['morty']['installation_path'] = current_value_172;
+    if (Array.isArray(current_value_172)){
+        default_config['tools']['modelsim']['vcom_options'] = current_value_172;
     }
             
-    // tools -> morty -> morty_options
+    // tools -> modelsim -> vlog_options
     let current_value_173 = undefined;
     try {
-        current_value_173 = json_config['tools']['morty']['morty_options'];
+        current_value_173 = json_config['tools']['modelsim']['vlog_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_173)){
-        default_config['tools']['morty']['morty_options'] = current_value_173;
+        default_config['tools']['modelsim']['vlog_options'] = current_value_173;
     }
             
-    // tools -> radiant -> installation_path
+    // tools -> modelsim -> vsim_options
     let current_value_174 = undefined;
     try {
-        current_value_174 = json_config['tools']['radiant']['installation_path'];
+        current_value_174 = json_config['tools']['modelsim']['vsim_options'];
     }
     catch(e){}
-    if (typeof current_value_174 === 'string'){
-        default_config['tools']['radiant']['installation_path'] = current_value_174;
+    if (Array.isArray(current_value_174)){
+        default_config['tools']['modelsim']['vsim_options'] = current_value_174;
     }
             
-    // tools -> radiant -> part
+    // tools -> morty -> installation_path
     let current_value_175 = undefined;
     try {
-        current_value_175 = json_config['tools']['radiant']['part'];
+        current_value_175 = json_config['tools']['morty']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_175 === 'string'){
-        default_config['tools']['radiant']['part'] = current_value_175;
+        default_config['tools']['morty']['installation_path'] = current_value_175;
     }
             
-    // tools -> rivierapro -> installation_path
+    // tools -> morty -> morty_options
     let current_value_176 = undefined;
     try {
-        current_value_176 = json_config['tools']['rivierapro']['installation_path'];
+        current_value_176 = json_config['tools']['morty']['morty_options'];
     }
     catch(e){}
-    if (typeof current_value_176 === 'string'){
-        default_config['tools']['rivierapro']['installation_path'] = current_value_176;
+    if (Array.isArray(current_value_176)){
+        default_config['tools']['morty']['morty_options'] = current_value_176;
     }
             
-    // tools -> rivierapro -> compilation_mode
+    // tools -> radiant -> installation_path
     let current_value_177 = undefined;
     try {
-        current_value_177 = json_config['tools']['rivierapro']['compilation_mode'];
+        current_value_177 = json_config['tools']['radiant']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_177 === 'string'){
-        default_config['tools']['rivierapro']['compilation_mode'] = current_value_177;
+        default_config['tools']['radiant']['installation_path'] = current_value_177;
     }
             
-    // tools -> rivierapro -> vlog_options
+    // tools -> radiant -> part
     let current_value_178 = undefined;
     try {
-        current_value_178 = json_config['tools']['rivierapro']['vlog_options'];
+        current_value_178 = json_config['tools']['radiant']['part'];
     }
     catch(e){}
-    if (Array.isArray(current_value_178)){
-        default_config['tools']['rivierapro']['vlog_options'] = current_value_178;
+    if (typeof current_value_178 === 'string'){
+        default_config['tools']['radiant']['part'] = current_value_178;
     }
             
-    // tools -> rivierapro -> vsim_options
+    // tools -> rivierapro -> installation_path
     let current_value_179 = undefined;
     try {
-        current_value_179 = json_config['tools']['rivierapro']['vsim_options'];
+        current_value_179 = json_config['tools']['rivierapro']['installation_path'];
     }
     catch(e){}
-    if (Array.isArray(current_value_179)){
-        default_config['tools']['rivierapro']['vsim_options'] = current_value_179;
+    if (typeof current_value_179 === 'string'){
+        default_config['tools']['rivierapro']['installation_path'] = current_value_179;
     }
             
-    // tools -> siliconcompiler -> installation_path
+    // tools -> rivierapro -> compilation_mode
     let current_value_180 = undefined;
     try {
-        current_value_180 = json_config['tools']['siliconcompiler']['installation_path'];
+        current_value_180 = json_config['tools']['rivierapro']['compilation_mode'];
     }
     catch(e){}
     if (typeof current_value_180 === 'string'){
-        default_config['tools']['siliconcompiler']['installation_path'] = current_value_180;
+        default_config['tools']['rivierapro']['compilation_mode'] = current_value_180;
     }
             
-    // tools -> siliconcompiler -> target
+    // tools -> rivierapro -> vlog_options
     let current_value_181 = undefined;
     try {
-        current_value_181 = json_config['tools']['siliconcompiler']['target'];
+        current_value_181 = json_config['tools']['rivierapro']['vlog_options'];
     }
     catch(e){}
-    if (typeof current_value_181 === 'string'){
-        default_config['tools']['siliconcompiler']['target'] = current_value_181;
+    if (Array.isArray(current_value_181)){
+        default_config['tools']['rivierapro']['vlog_options'] = current_value_181;
     }
             
-    // tools -> siliconcompiler -> server_enable
+    // tools -> rivierapro -> vsim_options
     let current_value_182 = undefined;
     try {
-        current_value_182 = json_config['tools']['siliconcompiler']['server_enable'];
+        current_value_182 = json_config['tools']['rivierapro']['vsim_options'];
     }
     catch(e){}
-    if (current_value_182 === true || current_value_182 === false){
-        default_config['tools']['siliconcompiler']['server_enable'] = current_value_182;
+    if (Array.isArray(current_value_182)){
+        default_config['tools']['rivierapro']['vsim_options'] = current_value_182;
     }
             
-    // tools -> siliconcompiler -> server_address
+    // tools -> siliconcompiler -> installation_path
     let current_value_183 = undefined;
     try {
-        current_value_183 = json_config['tools']['siliconcompiler']['server_address'];
+        current_value_183 = json_config['tools']['siliconcompiler']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_183 === 'string'){
-        default_config['tools']['siliconcompiler']['server_address'] = current_value_183;
+        default_config['tools']['siliconcompiler']['installation_path'] = current_value_183;
     }
             
-    // tools -> siliconcompiler -> server_username
+    // tools -> siliconcompiler -> target
     let current_value_184 = undefined;
     try {
-        current_value_184 = json_config['tools']['siliconcompiler']['server_username'];
+        current_value_184 = json_config['tools']['siliconcompiler']['target'];
     }
     catch(e){}
     if (typeof current_value_184 === 'string'){
-        default_config['tools']['siliconcompiler']['server_username'] = current_value_184;
+        default_config['tools']['siliconcompiler']['target'] = current_value_184;
     }
             
-    // tools -> siliconcompiler -> server_password
+    // tools -> siliconcompiler -> server_enable
     let current_value_185 = undefined;
     try {
-        current_value_185 = json_config['tools']['siliconcompiler']['server_password'];
+        current_value_185 = json_config['tools']['siliconcompiler']['server_enable'];
     }
     catch(e){}
-    if (typeof current_value_185 === 'string'){
-        default_config['tools']['siliconcompiler']['server_password'] = current_value_185;
+    if (current_value_185 === true || current_value_185 === false){
+        default_config['tools']['siliconcompiler']['server_enable'] = current_value_185;
     }
             
-    // tools -> spyglass -> installation_path
+    // tools -> siliconcompiler -> server_address
     let current_value_186 = undefined;
     try {
-        current_value_186 = json_config['tools']['spyglass']['installation_path'];
+        current_value_186 = json_config['tools']['siliconcompiler']['server_address'];
     }
     catch(e){}
     if (typeof current_value_186 === 'string'){
-        default_config['tools']['spyglass']['installation_path'] = current_value_186;
+        default_config['tools']['siliconcompiler']['server_address'] = current_value_186;
     }
             
-    // tools -> spyglass -> methodology
+    // tools -> siliconcompiler -> server_username
     let current_value_187 = undefined;
     try {
-        current_value_187 = json_config['tools']['spyglass']['methodology'];
+        current_value_187 = json_config['tools']['siliconcompiler']['server_username'];
     }
     catch(e){}
     if (typeof current_value_187 === 'string'){
-        default_config['tools']['spyglass']['methodology'] = current_value_187;
+        default_config['tools']['siliconcompiler']['server_username'] = current_value_187;
+    }
+            
+    // tools -> siliconcompiler -> server_password
+    let current_value_188 = undefined;
+    try {
+        current_value_188 = json_config['tools']['siliconcompiler']['server_password'];
+    }
+    catch(e){}
+    if (typeof current_value_188 === 'string'){
+        default_config['tools']['siliconcompiler']['server_password'] = current_value_188;
+    }
+            
+    // tools -> spyglass -> installation_path
+    let current_value_189 = undefined;
+    try {
+        current_value_189 = json_config['tools']['spyglass']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_189 === 'string'){
+        default_config['tools']['spyglass']['installation_path'] = current_value_189;
+    }
+            
+    // tools -> spyglass -> methodology
+    let current_value_190 = undefined;
+    try {
+        current_value_190 = json_config['tools']['spyglass']['methodology'];
+    }
+    catch(e){}
+    if (typeof current_value_190 === 'string'){
+        default_config['tools']['spyglass']['methodology'] = current_value_190;
     }
             
     // tools -> spyglass -> goals
-    let current_value_188 = undefined;
+    let current_value_191 = undefined;
     try {
-        current_value_188 = json_config['tools']['spyglass']['goals'];
+        current_value_191 = json_config['tools']['spyglass']['goals'];
     }
     catch(e){}
-    if (Array.isArray(current_value_188)){
-        default_config['tools']['spyglass']['goals'] = current_value_188;
+    if (Array.isArray(current_value_191)){
+        default_config['tools']['spyglass']['goals'] = current_value_191;
     }
             
     // tools -> spyglass -> spyglass_options
-    let current_value_189 = undefined;
-    try {
-        current_value_189 = json_config['tools']['spyglass']['spyglass_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_189)){
-        default_config['tools']['spyglass']['spyglass_options'] = current_value_189;
-    }
-            
-    // tools -> spyglass -> rule_parameters
-    let current_value_190 = undefined;
-    try {
-        current_value_190 = json_config['tools']['spyglass']['rule_parameters'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_190)){
-        default_config['tools']['spyglass']['rule_parameters'] = current_value_190;
-    }
-            
-    // tools -> symbiyosys -> installation_path
-    let current_value_191 = undefined;
-    try {
-        current_value_191 = json_config['tools']['symbiyosys']['installation_path'];
-    }
-    catch(e){}
-    if (typeof current_value_191 === 'string'){
-        default_config['tools']['symbiyosys']['installation_path'] = current_value_191;
-    }
-            
-    // tools -> symbiyosys -> tasknames
     let current_value_192 = undefined;
     try {
-        current_value_192 = json_config['tools']['symbiyosys']['tasknames'];
+        current_value_192 = json_config['tools']['spyglass']['spyglass_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_192)){
-        default_config['tools']['symbiyosys']['tasknames'] = current_value_192;
+        default_config['tools']['spyglass']['spyglass_options'] = current_value_192;
     }
             
-    // tools -> symbiflow -> installation_path
+    // tools -> spyglass -> rule_parameters
     let current_value_193 = undefined;
     try {
-        current_value_193 = json_config['tools']['symbiflow']['installation_path'];
+        current_value_193 = json_config['tools']['spyglass']['rule_parameters'];
     }
     catch(e){}
-    if (typeof current_value_193 === 'string'){
-        default_config['tools']['symbiflow']['installation_path'] = current_value_193;
+    if (Array.isArray(current_value_193)){
+        default_config['tools']['spyglass']['rule_parameters'] = current_value_193;
     }
             
-    // tools -> symbiflow -> package
+    // tools -> symbiyosys -> installation_path
     let current_value_194 = undefined;
     try {
-        current_value_194 = json_config['tools']['symbiflow']['package'];
+        current_value_194 = json_config['tools']['symbiyosys']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_194 === 'string'){
-        default_config['tools']['symbiflow']['package'] = current_value_194;
+        default_config['tools']['symbiyosys']['installation_path'] = current_value_194;
     }
             
-    // tools -> symbiflow -> part
+    // tools -> symbiyosys -> tasknames
     let current_value_195 = undefined;
     try {
-        current_value_195 = json_config['tools']['symbiflow']['part'];
+        current_value_195 = json_config['tools']['symbiyosys']['tasknames'];
     }
     catch(e){}
-    if (typeof current_value_195 === 'string'){
-        default_config['tools']['symbiflow']['part'] = current_value_195;
+    if (Array.isArray(current_value_195)){
+        default_config['tools']['symbiyosys']['tasknames'] = current_value_195;
     }
             
-    // tools -> symbiflow -> vendor
+    // tools -> symbiflow -> installation_path
     let current_value_196 = undefined;
     try {
-        current_value_196 = json_config['tools']['symbiflow']['vendor'];
+        current_value_196 = json_config['tools']['symbiflow']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_196 === 'string'){
-        default_config['tools']['symbiflow']['vendor'] = current_value_196;
+        default_config['tools']['symbiflow']['installation_path'] = current_value_196;
+    }
+            
+    // tools -> symbiflow -> package
+    let current_value_197 = undefined;
+    try {
+        current_value_197 = json_config['tools']['symbiflow']['package'];
+    }
+    catch(e){}
+    if (typeof current_value_197 === 'string'){
+        default_config['tools']['symbiflow']['package'] = current_value_197;
+    }
+            
+    // tools -> symbiflow -> part
+    let current_value_198 = undefined;
+    try {
+        current_value_198 = json_config['tools']['symbiflow']['part'];
+    }
+    catch(e){}
+    if (typeof current_value_198 === 'string'){
+        default_config['tools']['symbiflow']['part'] = current_value_198;
+    }
+            
+    // tools -> symbiflow -> vendor
+    let current_value_199 = undefined;
+    try {
+        current_value_199 = json_config['tools']['symbiflow']['vendor'];
+    }
+    catch(e){}
+    if (typeof current_value_199 === 'string'){
+        default_config['tools']['symbiflow']['vendor'] = current_value_199;
     }
             
     // tools -> symbiflow -> pnr
-    let current_value_197 = undefined;
+    let current_value_200 = undefined;
     try {
-        current_value_197 = json_config['tools']['symbiflow']['pnr'];
+        current_value_200 = json_config['tools']['symbiflow']['pnr'];
     }
     catch(e){}
-    if ( current_value_197 === "vpr"){
+    if ( current_value_200 === "vpr"){
         default_config['tools']['symbiflow']['pnr'] = e_tools_symbiflow_pnr.vpr;
     }
             
     // tools -> symbiflow -> vpr_options
-    let current_value_198 = undefined;
+    let current_value_201 = undefined;
     try {
-        current_value_198 = json_config['tools']['symbiflow']['vpr_options'];
+        current_value_201 = json_config['tools']['symbiflow']['vpr_options'];
     }
     catch(e){}
-    if (typeof current_value_198 === 'string'){
-        default_config['tools']['symbiflow']['vpr_options'] = current_value_198;
+    if (typeof current_value_201 === 'string'){
+        default_config['tools']['symbiflow']['vpr_options'] = current_value_201;
     }
             
     // tools -> symbiflow -> environment_script
-    let current_value_199 = undefined;
+    let current_value_202 = undefined;
     try {
-        current_value_199 = json_config['tools']['symbiflow']['environment_script'];
+        current_value_202 = json_config['tools']['symbiflow']['environment_script'];
     }
     catch(e){}
-    if (typeof current_value_199 === 'string'){
-        default_config['tools']['symbiflow']['environment_script'] = current_value_199;
+    if (typeof current_value_202 === 'string'){
+        default_config['tools']['symbiflow']['environment_script'] = current_value_202;
     }
             
     // tools -> trellis -> installation_path
-    let current_value_200 = undefined;
+    let current_value_203 = undefined;
     try {
-        current_value_200 = json_config['tools']['trellis']['installation_path'];
+        current_value_203 = json_config['tools']['trellis']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_200 === 'string'){
-        default_config['tools']['trellis']['installation_path'] = current_value_200;
+    if (typeof current_value_203 === 'string'){
+        default_config['tools']['trellis']['installation_path'] = current_value_203;
     }
             
     // tools -> trellis -> arch
-    let current_value_201 = undefined;
+    let current_value_204 = undefined;
     try {
-        current_value_201 = json_config['tools']['trellis']['arch'];
+        current_value_204 = json_config['tools']['trellis']['arch'];
     }
     catch(e){}
-    if ( current_value_201 === "xilinx"){
+    if ( current_value_204 === "xilinx"){
         default_config['tools']['trellis']['arch'] = e_tools_trellis_arch.xilinx;
     }
-    if ( current_value_201 === "ice40"){
+    if ( current_value_204 === "ice40"){
         default_config['tools']['trellis']['arch'] = e_tools_trellis_arch.ice40;
     }
-    if ( current_value_201 === "ecp5"){
+    if ( current_value_204 === "ecp5"){
         default_config['tools']['trellis']['arch'] = e_tools_trellis_arch.ecp5;
     }
             
     // tools -> trellis -> output_format
-    let current_value_202 = undefined;
+    let current_value_205 = undefined;
     try {
-        current_value_202 = json_config['tools']['trellis']['output_format'];
+        current_value_205 = json_config['tools']['trellis']['output_format'];
     }
     catch(e){}
-    if ( current_value_202 === "json"){
+    if ( current_value_205 === "json"){
         default_config['tools']['trellis']['output_format'] = e_tools_trellis_output_format.json;
     }
-    if ( current_value_202 === "edif"){
+    if ( current_value_205 === "edif"){
         default_config['tools']['trellis']['output_format'] = e_tools_trellis_output_format.edif;
     }
-    if ( current_value_202 === "blif"){
+    if ( current_value_205 === "blif"){
         default_config['tools']['trellis']['output_format'] = e_tools_trellis_output_format.blif;
     }
             
     // tools -> trellis -> yosys_as_subtool
-    let current_value_203 = undefined;
+    let current_value_206 = undefined;
     try {
-        current_value_203 = json_config['tools']['trellis']['yosys_as_subtool'];
+        current_value_206 = json_config['tools']['trellis']['yosys_as_subtool'];
     }
     catch(e){}
-    if (current_value_203 === true || current_value_203 === false){
-        default_config['tools']['trellis']['yosys_as_subtool'] = current_value_203;
+    if (current_value_206 === true || current_value_206 === false){
+        default_config['tools']['trellis']['yosys_as_subtool'] = current_value_206;
     }
             
     // tools -> trellis -> makefile_name
-    let current_value_204 = undefined;
+    let current_value_207 = undefined;
     try {
-        current_value_204 = json_config['tools']['trellis']['makefile_name'];
+        current_value_207 = json_config['tools']['trellis']['makefile_name'];
     }
     catch(e){}
-    if (typeof current_value_204 === 'string'){
-        default_config['tools']['trellis']['makefile_name'] = current_value_204;
+    if (typeof current_value_207 === 'string'){
+        default_config['tools']['trellis']['makefile_name'] = current_value_207;
     }
             
     // tools -> trellis -> script_name
-    let current_value_205 = undefined;
-    try {
-        current_value_205 = json_config['tools']['trellis']['script_name'];
-    }
-    catch(e){}
-    if (typeof current_value_205 === 'string'){
-        default_config['tools']['trellis']['script_name'] = current_value_205;
-    }
-            
-    // tools -> trellis -> nextpnr_options
-    let current_value_206 = undefined;
-    try {
-        current_value_206 = json_config['tools']['trellis']['nextpnr_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_206)){
-        default_config['tools']['trellis']['nextpnr_options'] = current_value_206;
-    }
-            
-    // tools -> trellis -> yosys_synth_options
-    let current_value_207 = undefined;
-    try {
-        current_value_207 = json_config['tools']['trellis']['yosys_synth_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_207)){
-        default_config['tools']['trellis']['yosys_synth_options'] = current_value_207;
-    }
-            
-    // tools -> vcs -> installation_path
     let current_value_208 = undefined;
     try {
-        current_value_208 = json_config['tools']['vcs']['installation_path'];
+        current_value_208 = json_config['tools']['trellis']['script_name'];
     }
     catch(e){}
     if (typeof current_value_208 === 'string'){
-        default_config['tools']['vcs']['installation_path'] = current_value_208;
+        default_config['tools']['trellis']['script_name'] = current_value_208;
     }
             
-    // tools -> vcs -> vcs_options
+    // tools -> trellis -> nextpnr_options
     let current_value_209 = undefined;
     try {
-        current_value_209 = json_config['tools']['vcs']['vcs_options'];
+        current_value_209 = json_config['tools']['trellis']['nextpnr_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_209)){
-        default_config['tools']['vcs']['vcs_options'] = current_value_209;
+        default_config['tools']['trellis']['nextpnr_options'] = current_value_209;
     }
             
-    // tools -> vcs -> run_options
+    // tools -> trellis -> yosys_synth_options
     let current_value_210 = undefined;
     try {
-        current_value_210 = json_config['tools']['vcs']['run_options'];
+        current_value_210 = json_config['tools']['trellis']['yosys_synth_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_210)){
-        default_config['tools']['vcs']['run_options'] = current_value_210;
+        default_config['tools']['trellis']['yosys_synth_options'] = current_value_210;
     }
             
-    // tools -> verible -> installation_path
+    // tools -> vcs -> installation_path
     let current_value_211 = undefined;
     try {
-        current_value_211 = json_config['tools']['verible']['installation_path'];
+        current_value_211 = json_config['tools']['vcs']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_211 === 'string'){
-        default_config['tools']['verible']['installation_path'] = current_value_211;
+        default_config['tools']['vcs']['installation_path'] = current_value_211;
+    }
+            
+    // tools -> vcs -> vcs_options
+    let current_value_212 = undefined;
+    try {
+        current_value_212 = json_config['tools']['vcs']['vcs_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_212)){
+        default_config['tools']['vcs']['vcs_options'] = current_value_212;
+    }
+            
+    // tools -> vcs -> run_options
+    let current_value_213 = undefined;
+    try {
+        current_value_213 = json_config['tools']['vcs']['run_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_213)){
+        default_config['tools']['vcs']['run_options'] = current_value_213;
+    }
+            
+    // tools -> verible -> installation_path
+    let current_value_214 = undefined;
+    try {
+        current_value_214 = json_config['tools']['verible']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_214 === 'string'){
+        default_config['tools']['verible']['installation_path'] = current_value_214;
     }
             
     // tools -> verilator -> installation_path
-    let current_value_212 = undefined;
+    let current_value_215 = undefined;
     try {
-        current_value_212 = json_config['tools']['verilator']['installation_path'];
+        current_value_215 = json_config['tools']['verilator']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_212 === 'string'){
-        default_config['tools']['verilator']['installation_path'] = current_value_212;
+    if (typeof current_value_215 === 'string'){
+        default_config['tools']['verilator']['installation_path'] = current_value_215;
     }
             
     // tools -> verilator -> mode
-    let current_value_213 = undefined;
+    let current_value_216 = undefined;
     try {
-        current_value_213 = json_config['tools']['verilator']['mode'];
+        current_value_216 = json_config['tools']['verilator']['mode'];
     }
     catch(e){}
-    if ( current_value_213 === "cc"){
+    if ( current_value_216 === "cc"){
         default_config['tools']['verilator']['mode'] = e_tools_verilator_mode.cc;
     }
-    if ( current_value_213 === "sc"){
+    if ( current_value_216 === "sc"){
         default_config['tools']['verilator']['mode'] = e_tools_verilator_mode.sc;
     }
-    if ( current_value_213 === "lint-only"){
+    if ( current_value_216 === "lint-only"){
         default_config['tools']['verilator']['mode'] = e_tools_verilator_mode.lint_only;
     }
             
     // tools -> verilator -> libs
-    let current_value_214 = undefined;
-    try {
-        current_value_214 = json_config['tools']['verilator']['libs'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_214)){
-        default_config['tools']['verilator']['libs'] = current_value_214;
-    }
-            
-    // tools -> verilator -> verilator_options
-    let current_value_215 = undefined;
-    try {
-        current_value_215 = json_config['tools']['verilator']['verilator_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_215)){
-        default_config['tools']['verilator']['verilator_options'] = current_value_215;
-    }
-            
-    // tools -> verilator -> make_options
-    let current_value_216 = undefined;
-    try {
-        current_value_216 = json_config['tools']['verilator']['make_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_216)){
-        default_config['tools']['verilator']['make_options'] = current_value_216;
-    }
-            
-    // tools -> verilator -> run_options
     let current_value_217 = undefined;
     try {
-        current_value_217 = json_config['tools']['verilator']['run_options'];
+        current_value_217 = json_config['tools']['verilator']['libs'];
     }
     catch(e){}
     if (Array.isArray(current_value_217)){
-        default_config['tools']['verilator']['run_options'] = current_value_217;
+        default_config['tools']['verilator']['libs'] = current_value_217;
+    }
+            
+    // tools -> verilator -> verilator_options
+    let current_value_218 = undefined;
+    try {
+        current_value_218 = json_config['tools']['verilator']['verilator_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_218)){
+        default_config['tools']['verilator']['verilator_options'] = current_value_218;
+    }
+            
+    // tools -> verilator -> make_options
+    let current_value_219 = undefined;
+    try {
+        current_value_219 = json_config['tools']['verilator']['make_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_219)){
+        default_config['tools']['verilator']['make_options'] = current_value_219;
+    }
+            
+    // tools -> verilator -> run_options
+    let current_value_220 = undefined;
+    try {
+        current_value_220 = json_config['tools']['verilator']['run_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_220)){
+        default_config['tools']['verilator']['run_options'] = current_value_220;
     }
             
     // tools -> vivado -> installation_path
-    let current_value_218 = undefined;
+    let current_value_221 = undefined;
     try {
-        current_value_218 = json_config['tools']['vivado']['installation_path'];
+        current_value_221 = json_config['tools']['vivado']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_218 === 'string'){
-        default_config['tools']['vivado']['installation_path'] = current_value_218;
+    if (typeof current_value_221 === 'string'){
+        default_config['tools']['vivado']['installation_path'] = current_value_221;
     }
             
     // tools -> vivado -> part
-    let current_value_219 = undefined;
+    let current_value_222 = undefined;
     try {
-        current_value_219 = json_config['tools']['vivado']['part'];
+        current_value_222 = json_config['tools']['vivado']['part'];
     }
     catch(e){}
-    if (typeof current_value_219 === 'string'){
-        default_config['tools']['vivado']['part'] = current_value_219;
+    if (typeof current_value_222 === 'string'){
+        default_config['tools']['vivado']['part'] = current_value_222;
     }
             
     // tools -> vivado -> synth
-    let current_value_220 = undefined;
+    let current_value_223 = undefined;
     try {
-        current_value_220 = json_config['tools']['vivado']['synth'];
+        current_value_223 = json_config['tools']['vivado']['synth'];
     }
     catch(e){}
-    if ( current_value_220 === "vivado"){
+    if ( current_value_223 === "vivado"){
         default_config['tools']['vivado']['synth'] = e_tools_vivado_synth.vivado;
     }
-    if ( current_value_220 === "yosys"){
+    if ( current_value_223 === "yosys"){
         default_config['tools']['vivado']['synth'] = e_tools_vivado_synth.yosys;
     }
             
     // tools -> vivado -> pnr
-    let current_value_221 = undefined;
+    let current_value_224 = undefined;
     try {
-        current_value_221 = json_config['tools']['vivado']['pnr'];
+        current_value_224 = json_config['tools']['vivado']['pnr'];
     }
     catch(e){}
-    if ( current_value_221 === "vivado"){
+    if ( current_value_224 === "vivado"){
         default_config['tools']['vivado']['pnr'] = e_tools_vivado_pnr.vivado;
     }
-    if ( current_value_221 === "none"){
+    if ( current_value_224 === "none"){
         default_config['tools']['vivado']['pnr'] = e_tools_vivado_pnr.none;
     }
             
     // tools -> vivado -> jtag_freq
-    let current_value_222 = undefined;
+    let current_value_225 = undefined;
     try {
-        current_value_222 = json_config['tools']['vivado']['jtag_freq'];
+        current_value_225 = json_config['tools']['vivado']['jtag_freq'];
     }
     catch(e){}
-    if (typeof current_value_222 === 'number'){
-        default_config['tools']['vivado']['jtag_freq'] = current_value_222;
+    if (typeof current_value_225 === 'number'){
+        default_config['tools']['vivado']['jtag_freq'] = current_value_225;
     }
             
     // tools -> vivado -> hw_target
-    let current_value_223 = undefined;
+    let current_value_226 = undefined;
     try {
-        current_value_223 = json_config['tools']['vivado']['hw_target'];
+        current_value_226 = json_config['tools']['vivado']['hw_target'];
     }
     catch(e){}
-    if (typeof current_value_223 === 'string'){
-        default_config['tools']['vivado']['hw_target'] = current_value_223;
+    if (typeof current_value_226 === 'string'){
+        default_config['tools']['vivado']['hw_target'] = current_value_226;
     }
             
     // tools -> vunit -> installation_path
-    let current_value_224 = undefined;
+    let current_value_227 = undefined;
     try {
-        current_value_224 = json_config['tools']['vunit']['installation_path'];
+        current_value_227 = json_config['tools']['vunit']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_224 === 'string'){
-        default_config['tools']['vunit']['installation_path'] = current_value_224;
+    if (typeof current_value_227 === 'string'){
+        default_config['tools']['vunit']['installation_path'] = current_value_227;
     }
             
     // tools -> vunit -> simulator_name
-    let current_value_225 = undefined;
+    let current_value_228 = undefined;
     try {
-        current_value_225 = json_config['tools']['vunit']['simulator_name'];
+        current_value_228 = json_config['tools']['vunit']['simulator_name'];
     }
     catch(e){}
-    if ( current_value_225 === "rivierapro"){
+    if ( current_value_228 === "rivierapro"){
         default_config['tools']['vunit']['simulator_name'] = e_tools_vunit_simulator_name.rivierapro;
     }
-    if ( current_value_225 === "activehdl"){
+    if ( current_value_228 === "activehdl"){
         default_config['tools']['vunit']['simulator_name'] = e_tools_vunit_simulator_name.activehdl;
     }
-    if ( current_value_225 === "ghdl"){
+    if ( current_value_228 === "ghdl"){
         default_config['tools']['vunit']['simulator_name'] = e_tools_vunit_simulator_name.ghdl;
     }
-    if ( current_value_225 === "modelsim"){
+    if ( current_value_228 === "modelsim"){
         default_config['tools']['vunit']['simulator_name'] = e_tools_vunit_simulator_name.modelsim;
     }
-    if ( current_value_225 === "xsim"){
+    if ( current_value_228 === "xsim"){
         default_config['tools']['vunit']['simulator_name'] = e_tools_vunit_simulator_name.xsim;
     }
             
     // tools -> vunit -> runpy_mode
-    let current_value_226 = undefined;
+    let current_value_229 = undefined;
     try {
-        current_value_226 = json_config['tools']['vunit']['runpy_mode'];
+        current_value_229 = json_config['tools']['vunit']['runpy_mode'];
     }
     catch(e){}
-    if ( current_value_226 === "standalone"){
+    if ( current_value_229 === "standalone"){
         default_config['tools']['vunit']['runpy_mode'] = e_tools_vunit_runpy_mode.standalone;
     }
-    if ( current_value_226 === "creation"){
+    if ( current_value_229 === "creation"){
         default_config['tools']['vunit']['runpy_mode'] = e_tools_vunit_runpy_mode.creation;
     }
             
     // tools -> vunit -> extra_options
-    let current_value_227 = undefined;
+    let current_value_230 = undefined;
     try {
-        current_value_227 = json_config['tools']['vunit']['extra_options'];
+        current_value_230 = json_config['tools']['vunit']['extra_options'];
     }
     catch(e){}
-    if (typeof current_value_227 === 'string'){
-        default_config['tools']['vunit']['extra_options'] = current_value_227;
+    if (typeof current_value_230 === 'string'){
+        default_config['tools']['vunit']['extra_options'] = current_value_230;
     }
             
     // tools -> vunit -> enable_array_util_lib
-    let current_value_228 = undefined;
-    try {
-        current_value_228 = json_config['tools']['vunit']['enable_array_util_lib'];
-    }
-    catch(e){}
-    if (current_value_228 === true || current_value_228 === false){
-        default_config['tools']['vunit']['enable_array_util_lib'] = current_value_228;
-    }
-            
-    // tools -> vunit -> enable_com_lib
-    let current_value_229 = undefined;
-    try {
-        current_value_229 = json_config['tools']['vunit']['enable_com_lib'];
-    }
-    catch(e){}
-    if (current_value_229 === true || current_value_229 === false){
-        default_config['tools']['vunit']['enable_com_lib'] = current_value_229;
-    }
-            
-    // tools -> vunit -> enable_json4vhdl_lib
-    let current_value_230 = undefined;
-    try {
-        current_value_230 = json_config['tools']['vunit']['enable_json4vhdl_lib'];
-    }
-    catch(e){}
-    if (current_value_230 === true || current_value_230 === false){
-        default_config['tools']['vunit']['enable_json4vhdl_lib'] = current_value_230;
-    }
-            
-    // tools -> vunit -> enable_osvvm_lib
     let current_value_231 = undefined;
     try {
-        current_value_231 = json_config['tools']['vunit']['enable_osvvm_lib'];
+        current_value_231 = json_config['tools']['vunit']['enable_array_util_lib'];
     }
     catch(e){}
     if (current_value_231 === true || current_value_231 === false){
-        default_config['tools']['vunit']['enable_osvvm_lib'] = current_value_231;
+        default_config['tools']['vunit']['enable_array_util_lib'] = current_value_231;
     }
             
-    // tools -> vunit -> enable_random_lib
+    // tools -> vunit -> enable_com_lib
     let current_value_232 = undefined;
     try {
-        current_value_232 = json_config['tools']['vunit']['enable_random_lib'];
+        current_value_232 = json_config['tools']['vunit']['enable_com_lib'];
     }
     catch(e){}
     if (current_value_232 === true || current_value_232 === false){
-        default_config['tools']['vunit']['enable_random_lib'] = current_value_232;
+        default_config['tools']['vunit']['enable_com_lib'] = current_value_232;
     }
             
-    // tools -> vunit -> enable_verification_components_lib
+    // tools -> vunit -> enable_json4vhdl_lib
     let current_value_233 = undefined;
     try {
-        current_value_233 = json_config['tools']['vunit']['enable_verification_components_lib'];
+        current_value_233 = json_config['tools']['vunit']['enable_json4vhdl_lib'];
     }
     catch(e){}
     if (current_value_233 === true || current_value_233 === false){
-        default_config['tools']['vunit']['enable_verification_components_lib'] = current_value_233;
+        default_config['tools']['vunit']['enable_json4vhdl_lib'] = current_value_233;
+    }
+            
+    // tools -> vunit -> enable_osvvm_lib
+    let current_value_234 = undefined;
+    try {
+        current_value_234 = json_config['tools']['vunit']['enable_osvvm_lib'];
+    }
+    catch(e){}
+    if (current_value_234 === true || current_value_234 === false){
+        default_config['tools']['vunit']['enable_osvvm_lib'] = current_value_234;
+    }
+            
+    // tools -> vunit -> enable_random_lib
+    let current_value_235 = undefined;
+    try {
+        current_value_235 = json_config['tools']['vunit']['enable_random_lib'];
+    }
+    catch(e){}
+    if (current_value_235 === true || current_value_235 === false){
+        default_config['tools']['vunit']['enable_random_lib'] = current_value_235;
+    }
+            
+    // tools -> vunit -> enable_verification_components_lib
+    let current_value_236 = undefined;
+    try {
+        current_value_236 = json_config['tools']['vunit']['enable_verification_components_lib'];
+    }
+    catch(e){}
+    if (current_value_236 === true || current_value_236 === false){
+        default_config['tools']['vunit']['enable_verification_components_lib'] = current_value_236;
     }
             
     // tools -> xcelium -> installation_path
-    let current_value_234 = undefined;
+    let current_value_237 = undefined;
     try {
-        current_value_234 = json_config['tools']['xcelium']['installation_path'];
+        current_value_237 = json_config['tools']['xcelium']['installation_path'];
     }
     catch(e){}
-    if (typeof current_value_234 === 'string'){
-        default_config['tools']['xcelium']['installation_path'] = current_value_234;
+    if (typeof current_value_237 === 'string'){
+        default_config['tools']['xcelium']['installation_path'] = current_value_237;
     }
             
     // tools -> xcelium -> xmvhdl_options
-    let current_value_235 = undefined;
-    try {
-        current_value_235 = json_config['tools']['xcelium']['xmvhdl_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_235)){
-        default_config['tools']['xcelium']['xmvhdl_options'] = current_value_235;
-    }
-            
-    // tools -> xcelium -> xmvlog_options
-    let current_value_236 = undefined;
-    try {
-        current_value_236 = json_config['tools']['xcelium']['xmvlog_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_236)){
-        default_config['tools']['xcelium']['xmvlog_options'] = current_value_236;
-    }
-            
-    // tools -> xcelium -> xmsim_options
-    let current_value_237 = undefined;
-    try {
-        current_value_237 = json_config['tools']['xcelium']['xmsim_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_237)){
-        default_config['tools']['xcelium']['xmsim_options'] = current_value_237;
-    }
-            
-    // tools -> xcelium -> xrun_options
     let current_value_238 = undefined;
     try {
-        current_value_238 = json_config['tools']['xcelium']['xrun_options'];
+        current_value_238 = json_config['tools']['xcelium']['xmvhdl_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_238)){
-        default_config['tools']['xcelium']['xrun_options'] = current_value_238;
+        default_config['tools']['xcelium']['xmvhdl_options'] = current_value_238;
     }
             
-    // tools -> xsim -> installation_path
+    // tools -> xcelium -> xmvlog_options
     let current_value_239 = undefined;
     try {
-        current_value_239 = json_config['tools']['xsim']['installation_path'];
+        current_value_239 = json_config['tools']['xcelium']['xmvlog_options'];
     }
     catch(e){}
-    if (typeof current_value_239 === 'string'){
-        default_config['tools']['xsim']['installation_path'] = current_value_239;
+    if (Array.isArray(current_value_239)){
+        default_config['tools']['xcelium']['xmvlog_options'] = current_value_239;
     }
             
-    // tools -> xsim -> xelab_options
+    // tools -> xcelium -> xmsim_options
     let current_value_240 = undefined;
     try {
-        current_value_240 = json_config['tools']['xsim']['xelab_options'];
+        current_value_240 = json_config['tools']['xcelium']['xmsim_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_240)){
-        default_config['tools']['xsim']['xelab_options'] = current_value_240;
+        default_config['tools']['xcelium']['xmsim_options'] = current_value_240;
     }
             
-    // tools -> xsim -> xsim_options
+    // tools -> xcelium -> xrun_options
     let current_value_241 = undefined;
     try {
-        current_value_241 = json_config['tools']['xsim']['xsim_options'];
+        current_value_241 = json_config['tools']['xcelium']['xrun_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_241)){
-        default_config['tools']['xsim']['xsim_options'] = current_value_241;
+        default_config['tools']['xcelium']['xrun_options'] = current_value_241;
     }
             
-    // tools -> yosys -> installation_path
+    // tools -> xsim -> installation_path
     let current_value_242 = undefined;
     try {
-        current_value_242 = json_config['tools']['yosys']['installation_path'];
+        current_value_242 = json_config['tools']['xsim']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_242 === 'string'){
-        default_config['tools']['yosys']['installation_path'] = current_value_242;
+        default_config['tools']['xsim']['installation_path'] = current_value_242;
     }
             
-    // tools -> yosys -> read_verilog_options
+    // tools -> xsim -> xelab_options
     let current_value_243 = undefined;
     try {
-        current_value_243 = json_config['tools']['yosys']['read_verilog_options'];
+        current_value_243 = json_config['tools']['xsim']['xelab_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_243)){
-        default_config['tools']['yosys']['read_verilog_options'] = current_value_243;
+        default_config['tools']['xsim']['xelab_options'] = current_value_243;
     }
             
-    // tools -> yosys -> read_systemverilog_options
+    // tools -> xsim -> xsim_options
     let current_value_244 = undefined;
     try {
-        current_value_244 = json_config['tools']['yosys']['read_systemverilog_options'];
+        current_value_244 = json_config['tools']['xsim']['xsim_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_244)){
-        default_config['tools']['yosys']['read_systemverilog_options'] = current_value_244;
+        default_config['tools']['xsim']['xsim_options'] = current_value_244;
     }
             
-    // tools -> yosys -> read_liberty_options
+    // tools -> yosys -> installation_path
     let current_value_245 = undefined;
     try {
-        current_value_245 = json_config['tools']['yosys']['read_liberty_options'];
+        current_value_245 = json_config['tools']['yosys']['installation_path'];
     }
     catch(e){}
-    if (Array.isArray(current_value_245)){
-        default_config['tools']['yosys']['read_liberty_options'] = current_value_245;
+    if (typeof current_value_245 === 'string'){
+        default_config['tools']['yosys']['installation_path'] = current_value_245;
     }
             
-    // tools -> yosys -> hierarchy_options
+    // tools -> yosys -> read_verilog_options
     let current_value_246 = undefined;
     try {
-        current_value_246 = json_config['tools']['yosys']['hierarchy_options'];
+        current_value_246 = json_config['tools']['yosys']['read_verilog_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_246)){
-        default_config['tools']['yosys']['hierarchy_options'] = current_value_246;
+        default_config['tools']['yosys']['read_verilog_options'] = current_value_246;
     }
             
-    // tools -> yosys -> proc_options
+    // tools -> yosys -> read_systemverilog_options
     let current_value_247 = undefined;
     try {
-        current_value_247 = json_config['tools']['yosys']['proc_options'];
+        current_value_247 = json_config['tools']['yosys']['read_systemverilog_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_247)){
-        default_config['tools']['yosys']['proc_options'] = current_value_247;
+        default_config['tools']['yosys']['read_systemverilog_options'] = current_value_247;
     }
             
-    // tools -> yosys -> opt_options
+    // tools -> yosys -> read_liberty_options
     let current_value_248 = undefined;
     try {
-        current_value_248 = json_config['tools']['yosys']['opt_options'];
+        current_value_248 = json_config['tools']['yosys']['read_liberty_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_248)){
-        default_config['tools']['yosys']['opt_options'] = current_value_248;
+        default_config['tools']['yosys']['read_liberty_options'] = current_value_248;
     }
             
-    // tools -> yosys -> flatten_enabled
+    // tools -> yosys -> hierarchy_options
     let current_value_249 = undefined;
     try {
-        current_value_249 = json_config['tools']['yosys']['flatten_enabled'];
+        current_value_249 = json_config['tools']['yosys']['hierarchy_options'];
     }
     catch(e){}
-    if (current_value_249 === true || current_value_249 === false){
-        default_config['tools']['yosys']['flatten_enabled'] = current_value_249;
+    if (Array.isArray(current_value_249)){
+        default_config['tools']['yosys']['hierarchy_options'] = current_value_249;
     }
             
-    // tools -> yosys -> flatten_options
+    // tools -> yosys -> proc_options
     let current_value_250 = undefined;
     try {
-        current_value_250 = json_config['tools']['yosys']['flatten_options'];
+        current_value_250 = json_config['tools']['yosys']['proc_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_250)){
-        default_config['tools']['yosys']['flatten_options'] = current_value_250;
+        default_config['tools']['yosys']['proc_options'] = current_value_250;
     }
             
-    // tools -> yosys -> memory_options
+    // tools -> yosys -> opt_options
     let current_value_251 = undefined;
     try {
-        current_value_251 = json_config['tools']['yosys']['memory_options'];
+        current_value_251 = json_config['tools']['yosys']['opt_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_251)){
-        default_config['tools']['yosys']['memory_options'] = current_value_251;
+        default_config['tools']['yosys']['opt_options'] = current_value_251;
     }
             
-    // tools -> yosys -> fsm_enabled
+    // tools -> yosys -> flatten_enabled
     let current_value_252 = undefined;
     try {
-        current_value_252 = json_config['tools']['yosys']['fsm_enabled'];
+        current_value_252 = json_config['tools']['yosys']['flatten_enabled'];
     }
     catch(e){}
     if (current_value_252 === true || current_value_252 === false){
-        default_config['tools']['yosys']['fsm_enabled'] = current_value_252;
+        default_config['tools']['yosys']['flatten_enabled'] = current_value_252;
     }
             
-    // tools -> yosys -> fsm_options
+    // tools -> yosys -> flatten_options
     let current_value_253 = undefined;
     try {
-        current_value_253 = json_config['tools']['yosys']['fsm_options'];
+        current_value_253 = json_config['tools']['yosys']['flatten_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_253)){
-        default_config['tools']['yosys']['fsm_options'] = current_value_253;
+        default_config['tools']['yosys']['flatten_options'] = current_value_253;
+    }
+            
+    // tools -> yosys -> memory_options
+    let current_value_254 = undefined;
+    try {
+        current_value_254 = json_config['tools']['yosys']['memory_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_254)){
+        default_config['tools']['yosys']['memory_options'] = current_value_254;
+    }
+            
+    // tools -> yosys -> fsm_enabled
+    let current_value_255 = undefined;
+    try {
+        current_value_255 = json_config['tools']['yosys']['fsm_enabled'];
+    }
+    catch(e){}
+    if (current_value_255 === true || current_value_255 === false){
+        default_config['tools']['yosys']['fsm_enabled'] = current_value_255;
+    }
+            
+    // tools -> yosys -> fsm_options
+    let current_value_256 = undefined;
+    try {
+        current_value_256 = json_config['tools']['yosys']['fsm_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_256)){
+        default_config['tools']['yosys']['fsm_options'] = current_value_256;
     }
             
     // tools -> yosys -> techmap_enabled
-    let current_value_254 = undefined;
+    let current_value_257 = undefined;
     try {
-        current_value_254 = json_config['tools']['yosys']['techmap_enabled'];
+        current_value_257 = json_config['tools']['yosys']['techmap_enabled'];
     }
     catch(e){}
-    if (current_value_254 === true || current_value_254 === false){
-        default_config['tools']['yosys']['techmap_enabled'] = current_value_254;
+    if (current_value_257 === true || current_value_257 === false){
+        default_config['tools']['yosys']['techmap_enabled'] = current_value_257;
     }
             
     // tools -> yosys -> techmap_options
-    let current_value_255 = undefined;
+    let current_value_258 = undefined;
     try {
-        current_value_255 = json_config['tools']['yosys']['techmap_options'];
+        current_value_258 = json_config['tools']['yosys']['techmap_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_255)){
-        default_config['tools']['yosys']['techmap_options'] = current_value_255;
+    if (Array.isArray(current_value_258)){
+        default_config['tools']['yosys']['techmap_options'] = current_value_258;
     }
             
     // tools -> yosys -> abc_enabled
-    let current_value_256 = undefined;
+    let current_value_259 = undefined;
     try {
-        current_value_256 = json_config['tools']['yosys']['abc_enabled'];
+        current_value_259 = json_config['tools']['yosys']['abc_enabled'];
     }
     catch(e){}
-    if (current_value_256 === true || current_value_256 === false){
-        default_config['tools']['yosys']['abc_enabled'] = current_value_256;
+    if (current_value_259 === true || current_value_259 === false){
+        default_config['tools']['yosys']['abc_enabled'] = current_value_259;
     }
             
     // tools -> yosys -> abc_options
-    let current_value_257 = undefined;
+    let current_value_260 = undefined;
     try {
-        current_value_257 = json_config['tools']['yosys']['abc_options'];
+        current_value_260 = json_config['tools']['yosys']['abc_options'];
     }
     catch(e){}
-    if (Array.isArray(current_value_257)){
-        default_config['tools']['yosys']['abc_options'] = current_value_257;
+    if (Array.isArray(current_value_260)){
+        default_config['tools']['yosys']['abc_options'] = current_value_260;
     }
             
     // tools -> yosys -> synthesis_target
-    let current_value_258 = undefined;
+    let current_value_261 = undefined;
     try {
-        current_value_258 = json_config['tools']['yosys']['synthesis_target'];
+        current_value_261 = json_config['tools']['yosys']['synthesis_target'];
     }
     catch(e){}
-    if ( current_value_258 === "ice40"){
+    if ( current_value_261 === "ice40"){
         default_config['tools']['yosys']['synthesis_target'] = e_tools_yosys_synthesis_target.ice40;
     }
-    if ( current_value_258 === "ecp5"){
+    if ( current_value_261 === "ecp5"){
         default_config['tools']['yosys']['synthesis_target'] = e_tools_yosys_synthesis_target.ecp5;
     }
             
     // tools -> yosys -> ice40_device
-    let current_value_259 = undefined;
+    let current_value_262 = undefined;
     try {
-        current_value_259 = json_config['tools']['yosys']['ice40_device'];
+        current_value_262 = json_config['tools']['yosys']['ice40_device'];
     }
     catch(e){}
-    if ( current_value_259 === "hx"){
+    if ( current_value_262 === "hx"){
         default_config['tools']['yosys']['ice40_device'] = e_tools_yosys_ice40_device.hx;
     }
-    if ( current_value_259 === "lp"){
+    if ( current_value_262 === "lp"){
         default_config['tools']['yosys']['ice40_device'] = e_tools_yosys_ice40_device.lp;
     }
-    if ( current_value_259 === "u"){
+    if ( current_value_262 === "u"){
         default_config['tools']['yosys']['ice40_device'] = e_tools_yosys_ice40_device.u;
     }
             
     // tools -> yosys -> ice40_top_module
-    let current_value_260 = undefined;
-    try {
-        current_value_260 = json_config['tools']['yosys']['ice40_top_module'];
-    }
-    catch(e){}
-    if (typeof current_value_260 === 'string'){
-        default_config['tools']['yosys']['ice40_top_module'] = current_value_260;
-    }
-            
-    // tools -> yosys -> ice40_output_blif
-    let current_value_261 = undefined;
-    try {
-        current_value_261 = json_config['tools']['yosys']['ice40_output_blif'];
-    }
-    catch(e){}
-    if (typeof current_value_261 === 'string'){
-        default_config['tools']['yosys']['ice40_output_blif'] = current_value_261;
-    }
-            
-    // tools -> yosys -> ice40_output_edif
-    let current_value_262 = undefined;
-    try {
-        current_value_262 = json_config['tools']['yosys']['ice40_output_edif'];
-    }
-    catch(e){}
-    if (typeof current_value_262 === 'string'){
-        default_config['tools']['yosys']['ice40_output_edif'] = current_value_262;
-    }
-            
-    // tools -> yosys -> ice40_output_json
     let current_value_263 = undefined;
     try {
-        current_value_263 = json_config['tools']['yosys']['ice40_output_json'];
+        current_value_263 = json_config['tools']['yosys']['ice40_top_module'];
     }
     catch(e){}
     if (typeof current_value_263 === 'string'){
-        default_config['tools']['yosys']['ice40_output_json'] = current_value_263;
+        default_config['tools']['yosys']['ice40_top_module'] = current_value_263;
+    }
+            
+    // tools -> yosys -> ice40_output_blif
+    let current_value_264 = undefined;
+    try {
+        current_value_264 = json_config['tools']['yosys']['ice40_output_blif'];
+    }
+    catch(e){}
+    if (typeof current_value_264 === 'string'){
+        default_config['tools']['yosys']['ice40_output_blif'] = current_value_264;
+    }
+            
+    // tools -> yosys -> ice40_output_edif
+    let current_value_265 = undefined;
+    try {
+        current_value_265 = json_config['tools']['yosys']['ice40_output_edif'];
+    }
+    catch(e){}
+    if (typeof current_value_265 === 'string'){
+        default_config['tools']['yosys']['ice40_output_edif'] = current_value_265;
+    }
+            
+    // tools -> yosys -> ice40_output_json
+    let current_value_266 = undefined;
+    try {
+        current_value_266 = json_config['tools']['yosys']['ice40_output_json'];
+    }
+    catch(e){}
+    if (typeof current_value_266 === 'string'){
+        default_config['tools']['yosys']['ice40_output_json'] = current_value_266;
     }
             
     // tools -> yosys -> ice40_noflatten
-    let current_value_264 = undefined;
-    try {
-        current_value_264 = json_config['tools']['yosys']['ice40_noflatten'];
-    }
-    catch(e){}
-    if (current_value_264 === true || current_value_264 === false){
-        default_config['tools']['yosys']['ice40_noflatten'] = current_value_264;
-    }
-            
-    // tools -> yosys -> ice40_dff
-    let current_value_265 = undefined;
-    try {
-        current_value_265 = json_config['tools']['yosys']['ice40_dff'];
-    }
-    catch(e){}
-    if (current_value_265 === true || current_value_265 === false){
-        default_config['tools']['yosys']['ice40_dff'] = current_value_265;
-    }
-            
-    // tools -> yosys -> ice40_retime
-    let current_value_266 = undefined;
-    try {
-        current_value_266 = json_config['tools']['yosys']['ice40_retime'];
-    }
-    catch(e){}
-    if (current_value_266 === true || current_value_266 === false){
-        default_config['tools']['yosys']['ice40_retime'] = current_value_266;
-    }
-            
-    // tools -> yosys -> ice40_nocarry
     let current_value_267 = undefined;
     try {
-        current_value_267 = json_config['tools']['yosys']['ice40_nocarry'];
+        current_value_267 = json_config['tools']['yosys']['ice40_noflatten'];
     }
     catch(e){}
     if (current_value_267 === true || current_value_267 === false){
-        default_config['tools']['yosys']['ice40_nocarry'] = current_value_267;
+        default_config['tools']['yosys']['ice40_noflatten'] = current_value_267;
     }
             
-    // tools -> yosys -> ice40_nodffe
+    // tools -> yosys -> ice40_dff
     let current_value_268 = undefined;
     try {
-        current_value_268 = json_config['tools']['yosys']['ice40_nodffe'];
+        current_value_268 = json_config['tools']['yosys']['ice40_dff'];
     }
     catch(e){}
     if (current_value_268 === true || current_value_268 === false){
-        default_config['tools']['yosys']['ice40_nodffe'] = current_value_268;
+        default_config['tools']['yosys']['ice40_dff'] = current_value_268;
     }
             
-    // tools -> yosys -> ice40_dffe_min_ce_use
+    // tools -> yosys -> ice40_retime
     let current_value_269 = undefined;
     try {
-        current_value_269 = json_config['tools']['yosys']['ice40_dffe_min_ce_use'];
+        current_value_269 = json_config['tools']['yosys']['ice40_retime'];
     }
     catch(e){}
-    if (typeof current_value_269 === 'number'){
-        default_config['tools']['yosys']['ice40_dffe_min_ce_use'] = current_value_269;
+    if (current_value_269 === true || current_value_269 === false){
+        default_config['tools']['yosys']['ice40_retime'] = current_value_269;
     }
             
-    // tools -> yosys -> ice40_nobram
+    // tools -> yosys -> ice40_nocarry
     let current_value_270 = undefined;
     try {
-        current_value_270 = json_config['tools']['yosys']['ice40_nobram'];
+        current_value_270 = json_config['tools']['yosys']['ice40_nocarry'];
     }
     catch(e){}
     if (current_value_270 === true || current_value_270 === false){
-        default_config['tools']['yosys']['ice40_nobram'] = current_value_270;
+        default_config['tools']['yosys']['ice40_nocarry'] = current_value_270;
     }
             
-    // tools -> yosys -> ice40_spram
+    // tools -> yosys -> ice40_nodffe
     let current_value_271 = undefined;
     try {
-        current_value_271 = json_config['tools']['yosys']['ice40_spram'];
+        current_value_271 = json_config['tools']['yosys']['ice40_nodffe'];
     }
     catch(e){}
     if (current_value_271 === true || current_value_271 === false){
-        default_config['tools']['yosys']['ice40_spram'] = current_value_271;
+        default_config['tools']['yosys']['ice40_nodffe'] = current_value_271;
     }
             
-    // tools -> yosys -> ice40_dsp
+    // tools -> yosys -> ice40_dffe_min_ce_use
     let current_value_272 = undefined;
     try {
-        current_value_272 = json_config['tools']['yosys']['ice40_dsp'];
+        current_value_272 = json_config['tools']['yosys']['ice40_dffe_min_ce_use'];
     }
     catch(e){}
-    if (current_value_272 === true || current_value_272 === false){
-        default_config['tools']['yosys']['ice40_dsp'] = current_value_272;
+    if (typeof current_value_272 === 'number'){
+        default_config['tools']['yosys']['ice40_dffe_min_ce_use'] = current_value_272;
     }
             
-    // tools -> yosys -> ice40_noabc
+    // tools -> yosys -> ice40_nobram
     let current_value_273 = undefined;
     try {
-        current_value_273 = json_config['tools']['yosys']['ice40_noabc'];
+        current_value_273 = json_config['tools']['yosys']['ice40_nobram'];
     }
     catch(e){}
     if (current_value_273 === true || current_value_273 === false){
-        default_config['tools']['yosys']['ice40_noabc'] = current_value_273;
+        default_config['tools']['yosys']['ice40_nobram'] = current_value_273;
     }
             
-    // tools -> yosys -> ice40_abc2
+    // tools -> yosys -> ice40_spram
     let current_value_274 = undefined;
     try {
-        current_value_274 = json_config['tools']['yosys']['ice40_abc2'];
+        current_value_274 = json_config['tools']['yosys']['ice40_spram'];
     }
     catch(e){}
     if (current_value_274 === true || current_value_274 === false){
-        default_config['tools']['yosys']['ice40_abc2'] = current_value_274;
+        default_config['tools']['yosys']['ice40_spram'] = current_value_274;
     }
             
-    // tools -> yosys -> ice40_vpr
+    // tools -> yosys -> ice40_dsp
     let current_value_275 = undefined;
     try {
-        current_value_275 = json_config['tools']['yosys']['ice40_vpr'];
+        current_value_275 = json_config['tools']['yosys']['ice40_dsp'];
     }
     catch(e){}
     if (current_value_275 === true || current_value_275 === false){
-        default_config['tools']['yosys']['ice40_vpr'] = current_value_275;
+        default_config['tools']['yosys']['ice40_dsp'] = current_value_275;
     }
             
-    // tools -> yosys -> ice40_noabc9
+    // tools -> yosys -> ice40_noabc
     let current_value_276 = undefined;
     try {
-        current_value_276 = json_config['tools']['yosys']['ice40_noabc9'];
+        current_value_276 = json_config['tools']['yosys']['ice40_noabc'];
     }
     catch(e){}
     if (current_value_276 === true || current_value_276 === false){
-        default_config['tools']['yosys']['ice40_noabc9'] = current_value_276;
+        default_config['tools']['yosys']['ice40_noabc'] = current_value_276;
     }
             
-    // tools -> yosys -> ice40_flowmap
+    // tools -> yosys -> ice40_abc2
     let current_value_277 = undefined;
     try {
-        current_value_277 = json_config['tools']['yosys']['ice40_flowmap'];
+        current_value_277 = json_config['tools']['yosys']['ice40_abc2'];
     }
     catch(e){}
     if (current_value_277 === true || current_value_277 === false){
-        default_config['tools']['yosys']['ice40_flowmap'] = current_value_277;
+        default_config['tools']['yosys']['ice40_abc2'] = current_value_277;
     }
             
-    // tools -> yosys -> ice40_no_rw_check
+    // tools -> yosys -> ice40_vpr
     let current_value_278 = undefined;
     try {
-        current_value_278 = json_config['tools']['yosys']['ice40_no_rw_check'];
+        current_value_278 = json_config['tools']['yosys']['ice40_vpr'];
     }
     catch(e){}
     if (current_value_278 === true || current_value_278 === false){
-        default_config['tools']['yosys']['ice40_no_rw_check'] = current_value_278;
+        default_config['tools']['yosys']['ice40_vpr'] = current_value_278;
+    }
+            
+    // tools -> yosys -> ice40_noabc9
+    let current_value_279 = undefined;
+    try {
+        current_value_279 = json_config['tools']['yosys']['ice40_noabc9'];
+    }
+    catch(e){}
+    if (current_value_279 === true || current_value_279 === false){
+        default_config['tools']['yosys']['ice40_noabc9'] = current_value_279;
+    }
+            
+    // tools -> yosys -> ice40_flowmap
+    let current_value_280 = undefined;
+    try {
+        current_value_280 = json_config['tools']['yosys']['ice40_flowmap'];
+    }
+    catch(e){}
+    if (current_value_280 === true || current_value_280 === false){
+        default_config['tools']['yosys']['ice40_flowmap'] = current_value_280;
+    }
+            
+    // tools -> yosys -> ice40_no_rw_check
+    let current_value_281 = undefined;
+    try {
+        current_value_281 = json_config['tools']['yosys']['ice40_no_rw_check'];
+    }
+    catch(e){}
+    if (current_value_281 === true || current_value_281 === false){
+        default_config['tools']['yosys']['ice40_no_rw_check'] = current_value_281;
     }
             
     // tools -> yosys -> ecp5_top_module
-    let current_value_279 = undefined;
-    try {
-        current_value_279 = json_config['tools']['yosys']['ecp5_top_module'];
-    }
-    catch(e){}
-    if (typeof current_value_279 === 'string'){
-        default_config['tools']['yosys']['ecp5_top_module'] = current_value_279;
-    }
-            
-    // tools -> yosys -> ecp5_output_blif
-    let current_value_280 = undefined;
-    try {
-        current_value_280 = json_config['tools']['yosys']['ecp5_output_blif'];
-    }
-    catch(e){}
-    if (typeof current_value_280 === 'string'){
-        default_config['tools']['yosys']['ecp5_output_blif'] = current_value_280;
-    }
-            
-    // tools -> yosys -> ecp5_output_edif
-    let current_value_281 = undefined;
-    try {
-        current_value_281 = json_config['tools']['yosys']['ecp5_output_edif'];
-    }
-    catch(e){}
-    if (typeof current_value_281 === 'string'){
-        default_config['tools']['yosys']['ecp5_output_edif'] = current_value_281;
-    }
-            
-    // tools -> yosys -> ecp5_output_json
     let current_value_282 = undefined;
     try {
-        current_value_282 = json_config['tools']['yosys']['ecp5_output_json'];
+        current_value_282 = json_config['tools']['yosys']['ecp5_top_module'];
     }
     catch(e){}
     if (typeof current_value_282 === 'string'){
-        default_config['tools']['yosys']['ecp5_output_json'] = current_value_282;
+        default_config['tools']['yosys']['ecp5_top_module'] = current_value_282;
+    }
+            
+    // tools -> yosys -> ecp5_output_blif
+    let current_value_283 = undefined;
+    try {
+        current_value_283 = json_config['tools']['yosys']['ecp5_output_blif'];
+    }
+    catch(e){}
+    if (typeof current_value_283 === 'string'){
+        default_config['tools']['yosys']['ecp5_output_blif'] = current_value_283;
+    }
+            
+    // tools -> yosys -> ecp5_output_edif
+    let current_value_284 = undefined;
+    try {
+        current_value_284 = json_config['tools']['yosys']['ecp5_output_edif'];
+    }
+    catch(e){}
+    if (typeof current_value_284 === 'string'){
+        default_config['tools']['yosys']['ecp5_output_edif'] = current_value_284;
+    }
+            
+    // tools -> yosys -> ecp5_output_json
+    let current_value_285 = undefined;
+    try {
+        current_value_285 = json_config['tools']['yosys']['ecp5_output_json'];
+    }
+    catch(e){}
+    if (typeof current_value_285 === 'string'){
+        default_config['tools']['yosys']['ecp5_output_json'] = current_value_285;
     }
             
     // tools -> yosys -> ecp5_noflatten
-    let current_value_283 = undefined;
-    try {
-        current_value_283 = json_config['tools']['yosys']['ecp5_noflatten'];
-    }
-    catch(e){}
-    if (current_value_283 === true || current_value_283 === false){
-        default_config['tools']['yosys']['ecp5_noflatten'] = current_value_283;
-    }
-            
-    // tools -> yosys -> ecp5_dff
-    let current_value_284 = undefined;
-    try {
-        current_value_284 = json_config['tools']['yosys']['ecp5_dff'];
-    }
-    catch(e){}
-    if (current_value_284 === true || current_value_284 === false){
-        default_config['tools']['yosys']['ecp5_dff'] = current_value_284;
-    }
-            
-    // tools -> yosys -> ecp5_retime
-    let current_value_285 = undefined;
-    try {
-        current_value_285 = json_config['tools']['yosys']['ecp5_retime'];
-    }
-    catch(e){}
-    if (current_value_285 === true || current_value_285 === false){
-        default_config['tools']['yosys']['ecp5_retime'] = current_value_285;
-    }
-            
-    // tools -> yosys -> ecp5_noccu2
     let current_value_286 = undefined;
     try {
-        current_value_286 = json_config['tools']['yosys']['ecp5_noccu2'];
+        current_value_286 = json_config['tools']['yosys']['ecp5_noflatten'];
     }
     catch(e){}
     if (current_value_286 === true || current_value_286 === false){
-        default_config['tools']['yosys']['ecp5_noccu2'] = current_value_286;
+        default_config['tools']['yosys']['ecp5_noflatten'] = current_value_286;
     }
             
-    // tools -> yosys -> ecp5_nodffe
+    // tools -> yosys -> ecp5_dff
     let current_value_287 = undefined;
     try {
-        current_value_287 = json_config['tools']['yosys']['ecp5_nodffe'];
+        current_value_287 = json_config['tools']['yosys']['ecp5_dff'];
     }
     catch(e){}
     if (current_value_287 === true || current_value_287 === false){
-        default_config['tools']['yosys']['ecp5_nodffe'] = current_value_287;
+        default_config['tools']['yosys']['ecp5_dff'] = current_value_287;
     }
             
-    // tools -> yosys -> ecp5_nobram
+    // tools -> yosys -> ecp5_retime
     let current_value_288 = undefined;
     try {
-        current_value_288 = json_config['tools']['yosys']['ecp5_nobram'];
+        current_value_288 = json_config['tools']['yosys']['ecp5_retime'];
     }
     catch(e){}
     if (current_value_288 === true || current_value_288 === false){
-        default_config['tools']['yosys']['ecp5_nobram'] = current_value_288;
+        default_config['tools']['yosys']['ecp5_retime'] = current_value_288;
     }
             
-    // tools -> yosys -> ecp5_nolutram
+    // tools -> yosys -> ecp5_noccu2
     let current_value_289 = undefined;
     try {
-        current_value_289 = json_config['tools']['yosys']['ecp5_nolutram'];
+        current_value_289 = json_config['tools']['yosys']['ecp5_noccu2'];
     }
     catch(e){}
     if (current_value_289 === true || current_value_289 === false){
-        default_config['tools']['yosys']['ecp5_nolutram'] = current_value_289;
+        default_config['tools']['yosys']['ecp5_noccu2'] = current_value_289;
     }
             
-    // tools -> yosys -> ecp5_nowidelut
+    // tools -> yosys -> ecp5_nodffe
     let current_value_290 = undefined;
     try {
-        current_value_290 = json_config['tools']['yosys']['ecp5_nowidelut'];
+        current_value_290 = json_config['tools']['yosys']['ecp5_nodffe'];
     }
     catch(e){}
     if (current_value_290 === true || current_value_290 === false){
-        default_config['tools']['yosys']['ecp5_nowidelut'] = current_value_290;
+        default_config['tools']['yosys']['ecp5_nodffe'] = current_value_290;
     }
             
-    // tools -> yosys -> ecp5_asyncprld
+    // tools -> yosys -> ecp5_nobram
     let current_value_291 = undefined;
     try {
-        current_value_291 = json_config['tools']['yosys']['ecp5_asyncprld'];
+        current_value_291 = json_config['tools']['yosys']['ecp5_nobram'];
     }
     catch(e){}
     if (current_value_291 === true || current_value_291 === false){
-        default_config['tools']['yosys']['ecp5_asyncprld'] = current_value_291;
+        default_config['tools']['yosys']['ecp5_nobram'] = current_value_291;
     }
             
-    // tools -> yosys -> ecp5_abc2
+    // tools -> yosys -> ecp5_nolutram
     let current_value_292 = undefined;
     try {
-        current_value_292 = json_config['tools']['yosys']['ecp5_abc2'];
+        current_value_292 = json_config['tools']['yosys']['ecp5_nolutram'];
     }
     catch(e){}
     if (current_value_292 === true || current_value_292 === false){
-        default_config['tools']['yosys']['ecp5_abc2'] = current_value_292;
+        default_config['tools']['yosys']['ecp5_nolutram'] = current_value_292;
     }
             
-    // tools -> yosys -> ecp5_noabc9
+    // tools -> yosys -> ecp5_nowidelut
     let current_value_293 = undefined;
     try {
-        current_value_293 = json_config['tools']['yosys']['ecp5_noabc9'];
+        current_value_293 = json_config['tools']['yosys']['ecp5_nowidelut'];
     }
     catch(e){}
     if (current_value_293 === true || current_value_293 === false){
-        default_config['tools']['yosys']['ecp5_noabc9'] = current_value_293;
+        default_config['tools']['yosys']['ecp5_nowidelut'] = current_value_293;
     }
             
-    // tools -> yosys -> ecp5_vpr
+    // tools -> yosys -> ecp5_asyncprld
     let current_value_294 = undefined;
     try {
-        current_value_294 = json_config['tools']['yosys']['ecp5_vpr'];
+        current_value_294 = json_config['tools']['yosys']['ecp5_asyncprld'];
     }
     catch(e){}
     if (current_value_294 === true || current_value_294 === false){
-        default_config['tools']['yosys']['ecp5_vpr'] = current_value_294;
+        default_config['tools']['yosys']['ecp5_asyncprld'] = current_value_294;
     }
             
-    // tools -> yosys -> ecp5_iopad
+    // tools -> yosys -> ecp5_abc2
     let current_value_295 = undefined;
     try {
-        current_value_295 = json_config['tools']['yosys']['ecp5_iopad'];
+        current_value_295 = json_config['tools']['yosys']['ecp5_abc2'];
     }
     catch(e){}
     if (current_value_295 === true || current_value_295 === false){
-        default_config['tools']['yosys']['ecp5_iopad'] = current_value_295;
+        default_config['tools']['yosys']['ecp5_abc2'] = current_value_295;
     }
             
-    // tools -> yosys -> ecp5_nodsp
+    // tools -> yosys -> ecp5_noabc9
     let current_value_296 = undefined;
     try {
-        current_value_296 = json_config['tools']['yosys']['ecp5_nodsp'];
+        current_value_296 = json_config['tools']['yosys']['ecp5_noabc9'];
     }
     catch(e){}
     if (current_value_296 === true || current_value_296 === false){
-        default_config['tools']['yosys']['ecp5_nodsp'] = current_value_296;
+        default_config['tools']['yosys']['ecp5_noabc9'] = current_value_296;
     }
             
-    // tools -> yosys -> ecp5_no_rw_check
+    // tools -> yosys -> ecp5_vpr
     let current_value_297 = undefined;
     try {
-        current_value_297 = json_config['tools']['yosys']['ecp5_no_rw_check'];
+        current_value_297 = json_config['tools']['yosys']['ecp5_vpr'];
     }
     catch(e){}
     if (current_value_297 === true || current_value_297 === false){
-        default_config['tools']['yosys']['ecp5_no_rw_check'] = current_value_297;
+        default_config['tools']['yosys']['ecp5_vpr'] = current_value_297;
     }
             
-    // tools -> yosys -> verbose
+    // tools -> yosys -> ecp5_iopad
     let current_value_298 = undefined;
     try {
-        current_value_298 = json_config['tools']['yosys']['verbose'];
+        current_value_298 = json_config['tools']['yosys']['ecp5_iopad'];
     }
     catch(e){}
     if (current_value_298 === true || current_value_298 === false){
-        default_config['tools']['yosys']['verbose'] = current_value_298;
+        default_config['tools']['yosys']['ecp5_iopad'] = current_value_298;
+    }
+            
+    // tools -> yosys -> ecp5_nodsp
+    let current_value_299 = undefined;
+    try {
+        current_value_299 = json_config['tools']['yosys']['ecp5_nodsp'];
+    }
+    catch(e){}
+    if (current_value_299 === true || current_value_299 === false){
+        default_config['tools']['yosys']['ecp5_nodsp'] = current_value_299;
+    }
+            
+    // tools -> yosys -> ecp5_no_rw_check
+    let current_value_300 = undefined;
+    try {
+        current_value_300 = json_config['tools']['yosys']['ecp5_no_rw_check'];
+    }
+    catch(e){}
+    if (current_value_300 === true || current_value_300 === false){
+        default_config['tools']['yosys']['ecp5_no_rw_check'] = current_value_300;
+    }
+            
+    // tools -> yosys -> verbose
+    let current_value_301 = undefined;
+    try {
+        current_value_301 = json_config['tools']['yosys']['verbose'];
+    }
+    catch(e){}
+    if (current_value_301 === true || current_value_301 === false){
+        default_config['tools']['yosys']['verbose'] = current_value_301;
     }
             
     // tools -> yosys -> debug_level
-    let current_value_299 = undefined;
+    let current_value_302 = undefined;
     try {
-        current_value_299 = json_config['tools']['yosys']['debug_level'];
+        current_value_302 = json_config['tools']['yosys']['debug_level'];
     }
     catch(e){}
-    if ( current_value_299 === "none"){
+    if ( current_value_302 === "none"){
         default_config['tools']['yosys']['debug_level'] = e_tools_yosys_debug_level.none;
     }
-    if ( current_value_299 === "basic"){
+    if ( current_value_302 === "basic"){
         default_config['tools']['yosys']['debug_level'] = e_tools_yosys_debug_level.basic;
     }
-    if ( current_value_299 === "detailed"){
+    if ( current_value_302 === "detailed"){
         default_config['tools']['yosys']['debug_level'] = e_tools_yosys_debug_level.detailed;
     }
-    if ( current_value_299 === "verbose"){
+    if ( current_value_302 === "verbose"){
         default_config['tools']['yosys']['debug_level'] = e_tools_yosys_debug_level.verbose;
     }
             
     // tools -> yosys -> log_file
-    let current_value_300 = undefined;
+    let current_value_303 = undefined;
     try {
-        current_value_300 = json_config['tools']['yosys']['log_file'];
+        current_value_303 = json_config['tools']['yosys']['log_file'];
     }
     catch(e){}
-    if (typeof current_value_300 === 'string'){
-        default_config['tools']['yosys']['log_file'] = current_value_300;
+    if (typeof current_value_303 === 'string'){
+        default_config['tools']['yosys']['log_file'] = current_value_303;
     }
             
     // tools -> yosys -> custom_load_commands
-    let current_value_301 = undefined;
-    try {
-        current_value_301 = json_config['tools']['yosys']['custom_load_commands'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_301)){
-        default_config['tools']['yosys']['custom_load_commands'] = current_value_301;
-    }
-            
-    // tools -> yosys -> custom_analyze_commands
-    let current_value_302 = undefined;
-    try {
-        current_value_302 = json_config['tools']['yosys']['custom_analyze_commands'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_302)){
-        default_config['tools']['yosys']['custom_analyze_commands'] = current_value_302;
-    }
-            
-    // tools -> yosys -> custom_elaborate_commands
-    let current_value_303 = undefined;
-    try {
-        current_value_303 = json_config['tools']['yosys']['custom_elaborate_commands'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_303)){
-        default_config['tools']['yosys']['custom_elaborate_commands'] = current_value_303;
-    }
-            
-    // tools -> yosys -> extra_flags
     let current_value_304 = undefined;
     try {
-        current_value_304 = json_config['tools']['yosys']['extra_flags'];
+        current_value_304 = json_config['tools']['yosys']['custom_load_commands'];
     }
     catch(e){}
     if (Array.isArray(current_value_304)){
-        default_config['tools']['yosys']['extra_flags'] = current_value_304;
+        default_config['tools']['yosys']['custom_load_commands'] = current_value_304;
     }
             
-    // tools -> yosys -> check_enabled
+    // tools -> yosys -> custom_analyze_commands
     let current_value_305 = undefined;
     try {
-        current_value_305 = json_config['tools']['yosys']['check_enabled'];
+        current_value_305 = json_config['tools']['yosys']['custom_analyze_commands'];
     }
     catch(e){}
-    if (current_value_305 === true || current_value_305 === false){
-        default_config['tools']['yosys']['check_enabled'] = current_value_305;
+    if (Array.isArray(current_value_305)){
+        default_config['tools']['yosys']['custom_analyze_commands'] = current_value_305;
     }
             
-    // tools -> yosys -> check_options
+    // tools -> yosys -> custom_elaborate_commands
     let current_value_306 = undefined;
     try {
-        current_value_306 = json_config['tools']['yosys']['check_options'];
+        current_value_306 = json_config['tools']['yosys']['custom_elaborate_commands'];
     }
     catch(e){}
     if (Array.isArray(current_value_306)){
-        default_config['tools']['yosys']['check_options'] = current_value_306;
+        default_config['tools']['yosys']['custom_elaborate_commands'] = current_value_306;
+    }
+            
+    // tools -> yosys -> extra_flags
+    let current_value_307 = undefined;
+    try {
+        current_value_307 = json_config['tools']['yosys']['extra_flags'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_307)){
+        default_config['tools']['yosys']['extra_flags'] = current_value_307;
+    }
+            
+    // tools -> yosys -> check_enabled
+    let current_value_308 = undefined;
+    try {
+        current_value_308 = json_config['tools']['yosys']['check_enabled'];
+    }
+    catch(e){}
+    if (current_value_308 === true || current_value_308 === false){
+        default_config['tools']['yosys']['check_enabled'] = current_value_308;
+    }
+            
+    // tools -> yosys -> check_options
+    let current_value_309 = undefined;
+    try {
+        current_value_309 = json_config['tools']['yosys']['check_options'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_309)){
+        default_config['tools']['yosys']['check_options'] = current_value_309;
     }
             
     // tools -> yosys -> stat_enabled
-    let current_value_307 = undefined;
+    let current_value_310 = undefined;
     try {
-        current_value_307 = json_config['tools']['yosys']['stat_enabled'];
+        current_value_310 = json_config['tools']['yosys']['stat_enabled'];
     }
     catch(e){}
-    if (current_value_307 === true || current_value_307 === false){
-        default_config['tools']['yosys']['stat_enabled'] = current_value_307;
+    if (current_value_310 === true || current_value_310 === false){
+        default_config['tools']['yosys']['stat_enabled'] = current_value_310;
     }
             
     // tools -> yosys -> stat_options
-    let current_value_308 = undefined;
-    try {
-        current_value_308 = json_config['tools']['yosys']['stat_options'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_308)){
-        default_config['tools']['yosys']['stat_options'] = current_value_308;
-    }
-            
-    // tools -> openfpga -> installation_path
-    let current_value_309 = undefined;
-    try {
-        current_value_309 = json_config['tools']['openfpga']['installation_path'];
-    }
-    catch(e){}
-    if (typeof current_value_309 === 'string'){
-        default_config['tools']['openfpga']['installation_path'] = current_value_309;
-    }
-            
-    // tools -> openfpga -> arch
-    let current_value_310 = undefined;
-    try {
-        current_value_310 = json_config['tools']['openfpga']['arch'];
-    }
-    catch(e){}
-    if (typeof current_value_310 === 'string'){
-        default_config['tools']['openfpga']['arch'] = current_value_310;
-    }
-            
-    // tools -> openfpga -> task_options
     let current_value_311 = undefined;
     try {
-        current_value_311 = json_config['tools']['openfpga']['task_options'];
+        current_value_311 = json_config['tools']['yosys']['stat_options'];
     }
     catch(e){}
     if (Array.isArray(current_value_311)){
-        default_config['tools']['openfpga']['task_options'] = current_value_311;
+        default_config['tools']['yosys']['stat_options'] = current_value_311;
     }
             
-    // tools -> activehdl -> installation_path
+    // tools -> openfpga -> installation_path
     let current_value_312 = undefined;
     try {
-        current_value_312 = json_config['tools']['activehdl']['installation_path'];
+        current_value_312 = json_config['tools']['openfpga']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_312 === 'string'){
-        default_config['tools']['activehdl']['installation_path'] = current_value_312;
+        default_config['tools']['openfpga']['installation_path'] = current_value_312;
     }
             
-    // tools -> questa -> installation_path
+    // tools -> openfpga -> arch
     let current_value_313 = undefined;
     try {
-        current_value_313 = json_config['tools']['questa']['installation_path'];
+        current_value_313 = json_config['tools']['openfpga']['arch'];
     }
     catch(e){}
     if (typeof current_value_313 === 'string'){
-        default_config['tools']['questa']['installation_path'] = current_value_313;
+        default_config['tools']['openfpga']['arch'] = current_value_313;
     }
             
-    // tools -> raptor -> installation_path
+    // tools -> openfpga -> task_options
     let current_value_314 = undefined;
     try {
-        current_value_314 = json_config['tools']['raptor']['installation_path'];
+        current_value_314 = json_config['tools']['openfpga']['task_options'];
     }
     catch(e){}
-    if (typeof current_value_314 === 'string'){
-        default_config['tools']['raptor']['installation_path'] = current_value_314;
+    if (Array.isArray(current_value_314)){
+        default_config['tools']['openfpga']['task_options'] = current_value_314;
     }
             
-    // tools -> raptor -> target_device
+    // tools -> activehdl -> installation_path
     let current_value_315 = undefined;
     try {
-        current_value_315 = json_config['tools']['raptor']['target_device'];
+        current_value_315 = json_config['tools']['activehdl']['installation_path'];
     }
     catch(e){}
     if (typeof current_value_315 === 'string'){
-        default_config['tools']['raptor']['target_device'] = current_value_315;
+        default_config['tools']['activehdl']['installation_path'] = current_value_315;
+    }
+            
+    // tools -> questa -> installation_path
+    let current_value_316 = undefined;
+    try {
+        current_value_316 = json_config['tools']['questa']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_316 === 'string'){
+        default_config['tools']['questa']['installation_path'] = current_value_316;
+    }
+            
+    // tools -> raptor -> installation_path
+    let current_value_317 = undefined;
+    try {
+        current_value_317 = json_config['tools']['raptor']['installation_path'];
+    }
+    catch(e){}
+    if (typeof current_value_317 === 'string'){
+        default_config['tools']['raptor']['installation_path'] = current_value_317;
+    }
+            
+    // tools -> raptor -> target_device
+    let current_value_318 = undefined;
+    try {
+        current_value_318 = json_config['tools']['raptor']['target_device'];
+    }
+    catch(e){}
+    if (typeof current_value_318 === 'string'){
+        default_config['tools']['raptor']['target_device'] = current_value_318;
     }
             
     // tools -> raptor -> vhdl_version
-    let current_value_316 = undefined;
+    let current_value_319 = undefined;
     try {
-        current_value_316 = json_config['tools']['raptor']['vhdl_version'];
+        current_value_319 = json_config['tools']['raptor']['vhdl_version'];
     }
     catch(e){}
-    if ( current_value_316 === "VHDL_1987"){
+    if ( current_value_319 === "VHDL_1987"){
         default_config['tools']['raptor']['vhdl_version'] = e_tools_raptor_vhdl_version.VHDL_1987;
     }
-    if ( current_value_316 === "VHDL_1993"){
+    if ( current_value_319 === "VHDL_1993"){
         default_config['tools']['raptor']['vhdl_version'] = e_tools_raptor_vhdl_version.VHDL_1993;
     }
-    if ( current_value_316 === "VHDL_2000"){
+    if ( current_value_319 === "VHDL_2000"){
         default_config['tools']['raptor']['vhdl_version'] = e_tools_raptor_vhdl_version.VHDL_2000;
     }
-    if ( current_value_316 === "VHDL_2008"){
+    if ( current_value_319 === "VHDL_2008"){
         default_config['tools']['raptor']['vhdl_version'] = e_tools_raptor_vhdl_version.VHDL_2008;
     }
-    if ( current_value_316 === "VHDL_2019"){
+    if ( current_value_319 === "VHDL_2019"){
         default_config['tools']['raptor']['vhdl_version'] = e_tools_raptor_vhdl_version.VHDL_2019;
     }
             
     // tools -> raptor -> verilog_version
-    let current_value_317 = undefined;
+    let current_value_320 = undefined;
     try {
-        current_value_317 = json_config['tools']['raptor']['verilog_version'];
+        current_value_320 = json_config['tools']['raptor']['verilog_version'];
     }
     catch(e){}
-    if ( current_value_317 === "V_1995"){
+    if ( current_value_320 === "V_1995"){
         default_config['tools']['raptor']['verilog_version'] = e_tools_raptor_verilog_version.V_1995;
     }
-    if ( current_value_317 === "V_2001"){
+    if ( current_value_320 === "V_2001"){
         default_config['tools']['raptor']['verilog_version'] = e_tools_raptor_verilog_version.V_2001;
     }
             
     // tools -> raptor -> sv_version
-    let current_value_318 = undefined;
+    let current_value_321 = undefined;
     try {
-        current_value_318 = json_config['tools']['raptor']['sv_version'];
+        current_value_321 = json_config['tools']['raptor']['sv_version'];
     }
     catch(e){}
-    if ( current_value_318 === "SV_2005"){
+    if ( current_value_321 === "SV_2005"){
         default_config['tools']['raptor']['sv_version'] = e_tools_raptor_sv_version.SV_2005;
     }
-    if ( current_value_318 === "SV_2009"){
+    if ( current_value_321 === "SV_2009"){
         default_config['tools']['raptor']['sv_version'] = e_tools_raptor_sv_version.SV_2009;
     }
-    if ( current_value_318 === "SV_2012"){
+    if ( current_value_321 === "SV_2012"){
         default_config['tools']['raptor']['sv_version'] = e_tools_raptor_sv_version.SV_2012;
     }
-    if ( current_value_318 === "SV_2017"){
+    if ( current_value_321 === "SV_2017"){
         default_config['tools']['raptor']['sv_version'] = e_tools_raptor_sv_version.SV_2017;
     }
             
     // tools -> raptor -> div_0
             
     // tools -> raptor -> optimization
-    let current_value_320 = undefined;
+    let current_value_323 = undefined;
     try {
-        current_value_320 = json_config['tools']['raptor']['optimization'];
+        current_value_323 = json_config['tools']['raptor']['optimization'];
     }
     catch(e){}
-    if ( current_value_320 === "area"){
+    if ( current_value_323 === "area"){
         default_config['tools']['raptor']['optimization'] = e_tools_raptor_optimization.area;
     }
-    if ( current_value_320 === "delay"){
+    if ( current_value_323 === "delay"){
         default_config['tools']['raptor']['optimization'] = e_tools_raptor_optimization.delay;
     }
-    if ( current_value_320 === "mixed"){
+    if ( current_value_323 === "mixed"){
         default_config['tools']['raptor']['optimization'] = e_tools_raptor_optimization.mixed;
     }
-    if ( current_value_320 === "none"){
+    if ( current_value_323 === "none"){
         default_config['tools']['raptor']['optimization'] = e_tools_raptor_optimization.none;
     }
             
     // tools -> raptor -> effort
-    let current_value_321 = undefined;
+    let current_value_324 = undefined;
     try {
-        current_value_321 = json_config['tools']['raptor']['effort'];
+        current_value_324 = json_config['tools']['raptor']['effort'];
     }
     catch(e){}
-    if ( current_value_321 === "high"){
+    if ( current_value_324 === "high"){
         default_config['tools']['raptor']['effort'] = e_tools_raptor_effort.high;
     }
-    if ( current_value_321 === "medium"){
+    if ( current_value_324 === "medium"){
         default_config['tools']['raptor']['effort'] = e_tools_raptor_effort.medium;
     }
-    if ( current_value_321 === "low"){
+    if ( current_value_324 === "low"){
         default_config['tools']['raptor']['effort'] = e_tools_raptor_effort.low;
     }
             
     // tools -> raptor -> fsm_encoding
-    let current_value_322 = undefined;
+    let current_value_325 = undefined;
     try {
-        current_value_322 = json_config['tools']['raptor']['fsm_encoding'];
+        current_value_325 = json_config['tools']['raptor']['fsm_encoding'];
     }
     catch(e){}
-    if ( current_value_322 === "binary"){
+    if ( current_value_325 === "binary"){
         default_config['tools']['raptor']['fsm_encoding'] = e_tools_raptor_fsm_encoding.binary;
     }
-    if ( current_value_322 === "onehot"){
+    if ( current_value_325 === "onehot"){
         default_config['tools']['raptor']['fsm_encoding'] = e_tools_raptor_fsm_encoding.onehot;
     }
             
     // tools -> raptor -> carry
-    let current_value_323 = undefined;
+    let current_value_326 = undefined;
     try {
-        current_value_323 = json_config['tools']['raptor']['carry'];
+        current_value_326 = json_config['tools']['raptor']['carry'];
     }
     catch(e){}
-    if ( current_value_323 === "auto"){
+    if ( current_value_326 === "auto"){
         default_config['tools']['raptor']['carry'] = e_tools_raptor_carry.auto;
     }
-    if ( current_value_323 === "all"){
+    if ( current_value_326 === "all"){
         default_config['tools']['raptor']['carry'] = e_tools_raptor_carry.all;
     }
-    if ( current_value_323 === "none"){
+    if ( current_value_326 === "none"){
         default_config['tools']['raptor']['carry'] = e_tools_raptor_carry.none;
     }
             
     // tools -> raptor -> pnr_netlist_language
-    let current_value_324 = undefined;
+    let current_value_327 = undefined;
     try {
-        current_value_324 = json_config['tools']['raptor']['pnr_netlist_language'];
+        current_value_327 = json_config['tools']['raptor']['pnr_netlist_language'];
     }
     catch(e){}
-    if ( current_value_324 === "blif"){
+    if ( current_value_327 === "blif"){
         default_config['tools']['raptor']['pnr_netlist_language'] = e_tools_raptor_pnr_netlist_language.blif;
     }
-    if ( current_value_324 === "edif"){
+    if ( current_value_327 === "edif"){
         default_config['tools']['raptor']['pnr_netlist_language'] = e_tools_raptor_pnr_netlist_language.edif;
     }
-    if ( current_value_324 === "verilog"){
+    if ( current_value_327 === "verilog"){
         default_config['tools']['raptor']['pnr_netlist_language'] = e_tools_raptor_pnr_netlist_language.verilog;
     }
-    if ( current_value_324 === "vhdl"){
+    if ( current_value_327 === "vhdl"){
         default_config['tools']['raptor']['pnr_netlist_language'] = e_tools_raptor_pnr_netlist_language.vhdl;
     }
             
     // tools -> raptor -> dsp_limit
-    let current_value_325 = undefined;
+    let current_value_328 = undefined;
     try {
-        current_value_325 = json_config['tools']['raptor']['dsp_limit'];
+        current_value_328 = json_config['tools']['raptor']['dsp_limit'];
     }
     catch(e){}
-    if (typeof current_value_325 === 'number'){
-        default_config['tools']['raptor']['dsp_limit'] = current_value_325;
+    if (typeof current_value_328 === 'number'){
+        default_config['tools']['raptor']['dsp_limit'] = current_value_328;
     }
             
     // tools -> raptor -> block_ram_limit
-    let current_value_326 = undefined;
+    let current_value_329 = undefined;
     try {
-        current_value_326 = json_config['tools']['raptor']['block_ram_limit'];
+        current_value_329 = json_config['tools']['raptor']['block_ram_limit'];
     }
     catch(e){}
-    if (typeof current_value_326 === 'number'){
-        default_config['tools']['raptor']['block_ram_limit'] = current_value_326;
+    if (typeof current_value_329 === 'number'){
+        default_config['tools']['raptor']['block_ram_limit'] = current_value_329;
     }
             
     // tools -> raptor -> fast_synthesis
-    let current_value_327 = undefined;
+    let current_value_330 = undefined;
     try {
-        current_value_327 = json_config['tools']['raptor']['fast_synthesis'];
+        current_value_330 = json_config['tools']['raptor']['fast_synthesis'];
     }
     catch(e){}
-    if (current_value_327 === true || current_value_327 === false){
-        default_config['tools']['raptor']['fast_synthesis'] = current_value_327;
+    if (current_value_330 === true || current_value_330 === false){
+        default_config['tools']['raptor']['fast_synthesis'] = current_value_330;
     }
             
     // tools -> raptor -> div_1
             
     // tools -> raptor -> top_level
-    let current_value_329 = undefined;
-    try {
-        current_value_329 = json_config['tools']['raptor']['top_level'];
-    }
-    catch(e){}
-    if (typeof current_value_329 === 'string'){
-        default_config['tools']['raptor']['top_level'] = current_value_329;
-    }
-            
-    // tools -> raptor -> sim_source_list
-    let current_value_330 = undefined;
-    try {
-        current_value_330 = json_config['tools']['raptor']['sim_source_list'];
-    }
-    catch(e){}
-    if (Array.isArray(current_value_330)){
-        default_config['tools']['raptor']['sim_source_list'] = current_value_330;
-    }
-            
-    // tools -> raptor -> simulate_rtl
-    let current_value_331 = undefined;
-    try {
-        current_value_331 = json_config['tools']['raptor']['simulate_rtl'];
-    }
-    catch(e){}
-    if (current_value_331 === true || current_value_331 === false){
-        default_config['tools']['raptor']['simulate_rtl'] = current_value_331;
-    }
-            
-    // tools -> raptor -> waveform_rtl
     let current_value_332 = undefined;
     try {
-        current_value_332 = json_config['tools']['raptor']['waveform_rtl'];
+        current_value_332 = json_config['tools']['raptor']['top_level'];
     }
     catch(e){}
     if (typeof current_value_332 === 'string'){
-        default_config['tools']['raptor']['waveform_rtl'] = current_value_332;
+        default_config['tools']['raptor']['top_level'] = current_value_332;
+    }
+            
+    // tools -> raptor -> sim_source_list
+    let current_value_333 = undefined;
+    try {
+        current_value_333 = json_config['tools']['raptor']['sim_source_list'];
+    }
+    catch(e){}
+    if (Array.isArray(current_value_333)){
+        default_config['tools']['raptor']['sim_source_list'] = current_value_333;
+    }
+            
+    // tools -> raptor -> simulate_rtl
+    let current_value_334 = undefined;
+    try {
+        current_value_334 = json_config['tools']['raptor']['simulate_rtl'];
+    }
+    catch(e){}
+    if (current_value_334 === true || current_value_334 === false){
+        default_config['tools']['raptor']['simulate_rtl'] = current_value_334;
+    }
+            
+    // tools -> raptor -> waveform_rtl
+    let current_value_335 = undefined;
+    try {
+        current_value_335 = json_config['tools']['raptor']['waveform_rtl'];
+    }
+    catch(e){}
+    if (typeof current_value_335 === 'string'){
+        default_config['tools']['raptor']['waveform_rtl'] = current_value_335;
     }
             
     // tools -> raptor -> simulator_rtl
-    let current_value_333 = undefined;
+    let current_value_336 = undefined;
     try {
-        current_value_333 = json_config['tools']['raptor']['simulator_rtl'];
+        current_value_336 = json_config['tools']['raptor']['simulator_rtl'];
     }
     catch(e){}
-    if ( current_value_333 === "verilator"){
+    if ( current_value_336 === "verilator"){
         default_config['tools']['raptor']['simulator_rtl'] = e_tools_raptor_simulator_rtl.verilator;
     }
-    if ( current_value_333 === "ghdl"){
+    if ( current_value_336 === "ghdl"){
         default_config['tools']['raptor']['simulator_rtl'] = e_tools_raptor_simulator_rtl.ghdl;
     }
-    if ( current_value_333 === "icarus"){
+    if ( current_value_336 === "icarus"){
         default_config['tools']['raptor']['simulator_rtl'] = e_tools_raptor_simulator_rtl.icarus;
     }
             
     // tools -> raptor -> simulation_options_rtl
-    let current_value_334 = undefined;
+    let current_value_337 = undefined;
     try {
-        current_value_334 = json_config['tools']['raptor']['simulation_options_rtl'];
+        current_value_337 = json_config['tools']['raptor']['simulation_options_rtl'];
     }
     catch(e){}
-    if (typeof current_value_334 === 'string'){
-        default_config['tools']['raptor']['simulation_options_rtl'] = current_value_334;
+    if (typeof current_value_337 === 'string'){
+        default_config['tools']['raptor']['simulation_options_rtl'] = current_value_337;
     }
             
     // tools -> raptor -> simulate_gate
-    let current_value_335 = undefined;
+    let current_value_338 = undefined;
     try {
-        current_value_335 = json_config['tools']['raptor']['simulate_gate'];
+        current_value_338 = json_config['tools']['raptor']['simulate_gate'];
     }
     catch(e){}
-    if (current_value_335 === true || current_value_335 === false){
-        default_config['tools']['raptor']['simulate_gate'] = current_value_335;
+    if (current_value_338 === true || current_value_338 === false){
+        default_config['tools']['raptor']['simulate_gate'] = current_value_338;
     }
             
     // tools -> raptor -> waveform_gate
-    let current_value_336 = undefined;
+    let current_value_339 = undefined;
     try {
-        current_value_336 = json_config['tools']['raptor']['waveform_gate'];
+        current_value_339 = json_config['tools']['raptor']['waveform_gate'];
     }
     catch(e){}
-    if (typeof current_value_336 === 'string'){
-        default_config['tools']['raptor']['waveform_gate'] = current_value_336;
+    if (typeof current_value_339 === 'string'){
+        default_config['tools']['raptor']['waveform_gate'] = current_value_339;
     }
             
     // tools -> raptor -> simulator_gate
-    let current_value_337 = undefined;
+    let current_value_340 = undefined;
     try {
-        current_value_337 = json_config['tools']['raptor']['simulator_gate'];
+        current_value_340 = json_config['tools']['raptor']['simulator_gate'];
     }
     catch(e){}
-    if ( current_value_337 === "verilator"){
+    if ( current_value_340 === "verilator"){
         default_config['tools']['raptor']['simulator_gate'] = e_tools_raptor_simulator_gate.verilator;
     }
-    if ( current_value_337 === "ghdl"){
+    if ( current_value_340 === "ghdl"){
         default_config['tools']['raptor']['simulator_gate'] = e_tools_raptor_simulator_gate.ghdl;
     }
-    if ( current_value_337 === "icarus"){
+    if ( current_value_340 === "icarus"){
         default_config['tools']['raptor']['simulator_gate'] = e_tools_raptor_simulator_gate.icarus;
     }
             
     // tools -> raptor -> simulation_options_gate
-    let current_value_338 = undefined;
+    let current_value_341 = undefined;
     try {
-        current_value_338 = json_config['tools']['raptor']['simulation_options_gate'];
+        current_value_341 = json_config['tools']['raptor']['simulation_options_gate'];
     }
     catch(e){}
-    if (typeof current_value_338 === 'string'){
-        default_config['tools']['raptor']['simulation_options_gate'] = current_value_338;
+    if (typeof current_value_341 === 'string'){
+        default_config['tools']['raptor']['simulation_options_gate'] = current_value_341;
     }
             
     // tools -> raptor -> simulate_pnr
-    let current_value_339 = undefined;
+    let current_value_342 = undefined;
     try {
-        current_value_339 = json_config['tools']['raptor']['simulate_pnr'];
+        current_value_342 = json_config['tools']['raptor']['simulate_pnr'];
     }
     catch(e){}
-    if (current_value_339 === true || current_value_339 === false){
-        default_config['tools']['raptor']['simulate_pnr'] = current_value_339;
+    if (current_value_342 === true || current_value_342 === false){
+        default_config['tools']['raptor']['simulate_pnr'] = current_value_342;
     }
             
     // tools -> raptor -> waveform_pnr
-    let current_value_340 = undefined;
+    let current_value_343 = undefined;
     try {
-        current_value_340 = json_config['tools']['raptor']['waveform_pnr'];
+        current_value_343 = json_config['tools']['raptor']['waveform_pnr'];
     }
     catch(e){}
-    if (typeof current_value_340 === 'string'){
-        default_config['tools']['raptor']['waveform_pnr'] = current_value_340;
+    if (typeof current_value_343 === 'string'){
+        default_config['tools']['raptor']['waveform_pnr'] = current_value_343;
     }
             
     // tools -> raptor -> simulator_pnr
-    let current_value_341 = undefined;
+    let current_value_344 = undefined;
     try {
-        current_value_341 = json_config['tools']['raptor']['simulator_pnr'];
+        current_value_344 = json_config['tools']['raptor']['simulator_pnr'];
     }
     catch(e){}
-    if ( current_value_341 === "verilator"){
+    if ( current_value_344 === "verilator"){
         default_config['tools']['raptor']['simulator_pnr'] = e_tools_raptor_simulator_pnr.verilator;
     }
-    if ( current_value_341 === "ghdl"){
+    if ( current_value_344 === "ghdl"){
         default_config['tools']['raptor']['simulator_pnr'] = e_tools_raptor_simulator_pnr.ghdl;
     }
-    if ( current_value_341 === "icarus"){
+    if ( current_value_344 === "icarus"){
         default_config['tools']['raptor']['simulator_pnr'] = e_tools_raptor_simulator_pnr.icarus;
     }
             
     // tools -> raptor -> simulation_options_pnr
-    let current_value_342 = undefined;
+    let current_value_345 = undefined;
     try {
-        current_value_342 = json_config['tools']['raptor']['simulation_options_pnr'];
+        current_value_345 = json_config['tools']['raptor']['simulation_options_pnr'];
     }
     catch(e){}
-    if (typeof current_value_342 === 'string'){
-        default_config['tools']['raptor']['simulation_options_pnr'] = current_value_342;
+    if (typeof current_value_345 === 'string'){
+        default_config['tools']['raptor']['simulation_options_pnr'] = current_value_345;
     }
             
 

--- a/src/colibri/config/config_declaration.ts
+++ b/src/colibri/config/config_declaration.ts
@@ -228,7 +228,9 @@ export type e_tools_general = {
     execution_mode : e_tools_general_execution_mode,
     waveform_viewer : e_tools_general_waveform_viewer,
     gtkwave_installation_path : string,
+    surfer_installation_path : string,
     gtkwave_extra_arguments : string,
+    surfer_extra_arguments : string,
 };
     
 export type e_tools_quartus = {
@@ -762,6 +764,7 @@ export enum e_tools_general_waveform_viewer {
     tool = "tool",
     vaporView = "vaporView",
     gtkwave = "gtkwave",
+    surfer = "surfer",
 }
 export enum e_tools_quartus_optimization_mode {
     BALANCED = "BALANCED",
@@ -1115,6 +1118,8 @@ export function get_default_config(): e_config {
                 waveform_viewer : e_tools_general_waveform_viewer.tool,
                 gtkwave_installation_path : "",
                 gtkwave_extra_arguments : "",
+                surfer_installation_path : "",
+                surfer_extra_arguments : "",
             },
             quartus: {
                 installation_path : "",

--- a/src/colibri/config/config_web.ts
+++ b/src/colibri/config/config_web.ts
@@ -1996,10 +1996,10 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-checkbox">
-                            <input type="checkbox" id="tools-general-vaporview_import_signals">
-                            <label class="setting-checkbox-label" for="tools-general-vaporview_import_signals">
+                            <input type="checkbox" id="tools-general-vaporview_load_all_signals">
+                            <label class="setting-checkbox-label" for="tools-general-vaporview_load_all_signals">
                                 Import signals automatically in VaporView.
-                                <span class="markConfig" id="mark_tools-general-vaporview_import_signals"></span>
+                                <span class="markConfig" id="mark_tools-general-vaporview_load_all_signals"></span>
                             </label>
                         </div>
                     </div>
@@ -6009,8 +6009,8 @@ body.vscode-high-contrast {
     config["tools"]["general"]["execution_mode"] = element_value
     element_value = document.getElementById("tools-general-waveform_viewer").value;
     config["tools"]["general"]["waveform_viewer"] = element_value
-    element_value = document.getElementById("tools-general-vaporview_import_signals").checked;
-    config["tools"]["general"]["vaporview_import_signals"] = element_value
+    element_value = document.getElementById("tools-general-vaporview_load_all_signals").checked;
+    config["tools"]["general"]["vaporview_load_all_signals"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_installation_path").value;
     config["tools"]["general"]["gtkwave_installation_path"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_extra_arguments").value;
@@ -7024,8 +7024,8 @@ body.vscode-high-contrast {
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["waveform_viewer"] !== undefined) {
         document.getElementById("tools-general-waveform_viewer").value = config["tools"]["general"]["waveform_viewer"];
     }
-    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
-        document.getElementById("tools-general-vaporview_import_signals").checked = config["tools"]["general"]["vaporview_import_signals"];
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_load_all_signals"] !== undefined) {
+        document.getElementById("tools-general-vaporview_load_all_signals").checked = config["tools"]["general"]["vaporview_load_all_signals"];
     }
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
         document.getElementById("tools-general-gtkwave_installation_path").value = config["tools"]["general"]["gtkwave_installation_path"];
@@ -8212,10 +8212,10 @@ body.vscode-high-contrast {
     }
     document.getElementById("mark_tools-general-waveform_viewer").innerHTML = mark;
     mark = "";
-    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_load_all_signals"] !== undefined) {
       mark = MODIFIEDMSG;
     }
-    document.getElementById("mark_tools-general-vaporview_import_signals").innerHTML = mark;
+    document.getElementById("mark_tools-general-vaporview_load_all_signals").innerHTML = mark;
     mark = "";
     if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
       mark = MODIFIEDMSG;

--- a/src/colibri/config/config_web.ts
+++ b/src/colibri/config/config_web.ts
@@ -1980,7 +1980,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Select the waveform viewer. For GTKWave you need to install it.
+                            Select the waveform viewer. For GTKWave/Surfer you need to install it.
                             <span class="markConfig" id="mark_tools-general-waveform_viewer"></span>
                         </div>
                         <div class="select-container">
@@ -1988,7 +1988,19 @@ body.vscode-high-contrast {
                                       <option value='tool'>Tool GUI</option>
                                       <option value='vaporView'>VaporView</option>
                                       <option value='gtkwave'>GTKWave</option>
+                                      <option value='surfer'>Surfer</option>
                             </select>
+                        </div>
+                    </div>
+                  
+                  
+                    <div class="setting-item">
+                        <div class="setting-checkbox">
+                            <input type="checkbox" id="tools-general-vaporview_import_signals">
+                            <label class="setting-checkbox-label" for="tools-general-vaporview_import_signals">
+                                Import signals automatically in VaporView.
+                                <span class="markConfig" id="mark_tools-general-vaporview_import_signals"></span>
+                            </label>
                         </div>
                     </div>
                   
@@ -2011,13 +2023,31 @@ body.vscode-high-contrast {
                     </div>
                   
                   
+                    <div class="setting-item">
+                        <div class="setting-item-label">
+                            Surfer installation directory.
+                            <span class="markConfig" id="mark_tools-general-surfer_installation_path"></span>
+                        </div>
+                            <input class="setting-input-box" id="tools-general-surfer_installation_path" value="">
+                    </div>
+                  
+                  
+                    <div class="setting-item">
+                        <div class="setting-item-label">
+                            Extra arguments passed to Surfer. E.g: --script=script.tcl
+                            <span class="markConfig" id="mark_tools-general-surfer_extra_arguments"></span>
+                        </div>
+                            <input class="setting-input-box" id="tools-general-surfer_extra_arguments" value="">
+                    </div>
+                  
+                  
                   
             </div>
             <div class="settings-section" id="tools-quartus">
                 <div class="settings-group-title-label">
                     Tools: Intel@ Quartus@ Prime
                 </div>
-                <div class="settings-group-description">The intuitive high-performance design environment. From design entry and synthesis to optimization, verification, and simulation, Intel® Quartus® Prime Design Software unlocks increased capabilities on devices with multi-million logic elements, providing designers with the ideal platform to meet next-generation design opportunities.</div>
+                <div class="settings-group-description">The intuitive high-performance design environment. From design entry and synthesis to optimization, verification, and simulation, IntelÂ® QuartusÂ® Prime Design Software unlocks increased capabilities on devices with multi-million logic elements, providing designers with the ideal platform to meet next-generation design opportunities.</div>
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
@@ -2259,7 +2289,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Any argument to be passed to the “first” invocation of a simulator that runs via a TCL script. One motivating usage is to pass -noautoldlibpath to Questa to prevent it from loading the out-of-date libraries it ships with. Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator.
+                            Any argument to be passed to the "first" invocation of a simulator that runs via a TCL script. One motivating usage is to pass -noautoldlibpath to Questa to prevent it from loading the out-of-date libraries it ships with. Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator.
                             <span class="markConfig" id="mark_tools-cocotb-run_args"></span>
                         </div>
                             <input class="setting-input-box" id="tools-cocotb-run_args" value="">
@@ -3439,7 +3469,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            A list of the .sby file’s tasks to run. Passed on the sby command line..
+                            A list of the .sby fileâ€™s tasks to run. Passed on the sby command line..
                             <span class="markConfig" id="mark_tools-symbiyosys-tasknames"></span>
                         </div>
                         <div class="setting-item-description">Comma separated values</div>
@@ -3483,7 +3513,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Target architecture. Currently only “xilinx” is supported.
+                            Target architecture. Currently only "xilinx" is supported.
                             <span class="markConfig" id="mark_tools-symbiflow-vendor"></span>
                         </div>
                             <input class="setting-input-box" id="tools-symbiflow-vendor" value="">
@@ -3492,7 +3522,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Place and Route tool. Currently only “vpr” is supported.
+                            Place and Route tool. Currently only "vpr" is supported.
                             <span class="markConfig" id="mark_tools-symbiflow-pnr"></span>
                         </div>
                         <div class="select-container">
@@ -4825,7 +4855,7 @@ body.vscode-high-contrast {
                 <div class="settings-group-title-label">
                     Tools: Active-HDL
                 </div>
-                <div class="settings-group-description">Active-HDL™ is a Windows based, integrated FPGA Design Creation and Simulation solution for team-based environments.</div>
+                <div class="settings-group-description">Active-HDLâ„¢ is a Windows based, integrated FPGA Design Creation and Simulation solution for team-based environments.</div>
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
@@ -5979,10 +6009,16 @@ body.vscode-high-contrast {
     config["tools"]["general"]["execution_mode"] = element_value
     element_value = document.getElementById("tools-general-waveform_viewer").value;
     config["tools"]["general"]["waveform_viewer"] = element_value
+    element_value = document.getElementById("tools-general-vaporview_import_signals").checked;
+    config["tools"]["general"]["vaporview_import_signals"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_installation_path").value;
     config["tools"]["general"]["gtkwave_installation_path"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_extra_arguments").value;
     config["tools"]["general"]["gtkwave_extra_arguments"] = element_value
+    element_value = document.getElementById("tools-general-surfer_installation_path").value;
+    config["tools"]["general"]["surfer_installation_path"] = element_value
+    element_value = document.getElementById("tools-general-surfer_extra_arguments").value;
+    config["tools"]["general"]["surfer_extra_arguments"] = element_value
     config["tools"]["quartus"] = {}
     element_value = document.getElementById("tools-quartus-installation_path").value;
     config["tools"]["quartus"]["installation_path"] = element_value
@@ -6988,11 +7024,20 @@ body.vscode-high-contrast {
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["waveform_viewer"] !== undefined) {
         document.getElementById("tools-general-waveform_viewer").value = config["tools"]["general"]["waveform_viewer"];
     }
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
+        document.getElementById("tools-general-vaporview_import_signals").checked = config["tools"]["general"]["vaporview_import_signals"];
+    }
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
         document.getElementById("tools-general-gtkwave_installation_path").value = config["tools"]["general"]["gtkwave_installation_path"];
     }
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_extra_arguments"] !== undefined) {
         document.getElementById("tools-general-gtkwave_extra_arguments").value = config["tools"]["general"]["gtkwave_extra_arguments"];
+    }
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_installation_path"] !== undefined) {
+        document.getElementById("tools-general-surfer_installation_path").value = config["tools"]["general"]["surfer_installation_path"];
+    }
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_extra_arguments"] !== undefined) {
+        document.getElementById("tools-general-surfer_extra_arguments").value = config["tools"]["general"]["surfer_extra_arguments"];
     }
     if (config["tools"] && config["tools"]["quartus"] && config["tools"]["quartus"]["installation_path"] !== undefined) {
         document.getElementById("tools-quartus-installation_path").value = config["tools"]["quartus"]["installation_path"];
@@ -8167,6 +8212,11 @@ body.vscode-high-contrast {
     }
     document.getElementById("mark_tools-general-waveform_viewer").innerHTML = mark;
     mark = "";
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
+      mark = MODIFIEDMSG;
+    }
+    document.getElementById("mark_tools-general-vaporview_import_signals").innerHTML = mark;
+    mark = "";
     if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
       mark = MODIFIEDMSG;
     }
@@ -8176,6 +8226,16 @@ body.vscode-high-contrast {
       mark = MODIFIEDMSG;
     }
     document.getElementById("mark_tools-general-gtkwave_extra_arguments").innerHTML = mark;
+    mark = "";
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_installation_path"] !== undefined) {
+      mark = MODIFIEDMSG;
+    }
+    document.getElementById("mark_tools-general-surfer_installation_path").innerHTML = mark;
+    mark = "";
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_extra_arguments"] !== undefined) {
+      mark = MODIFIEDMSG;
+    }
+    document.getElementById("mark_tools-general-surfer_extra_arguments").innerHTML = mark;
     mark = "";
     if (projectName !== undefined && config["tools"] && config["tools"]["quartus"] && config["tools"]["quartus"]["installation_path"] !== undefined) {
       mark = MODIFIEDMSG;

--- a/src/colibri/config/helpers/configs/tools/cocotb.yml
+++ b/src/colibri/config/helpers/configs/tools/cocotb.yml
@@ -26,7 +26,7 @@ compile_args:
   value: ""
 
 run_args:
-  description: "Any argument to be passed to the “first” invocation of a simulator that runs via a TCL script. One motivating usage is to pass -noautoldlibpath to Questa to prevent it from loading the out-of-date libraries it ships with. Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator."
+  description: "Any argument to be passed to the \"first\" invocation of a simulator that runs via a TCL script. One motivating usage is to pass -noautoldlibpath to Questa to prevent it from loading the out-of-date libraries it ships with. Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator."
   type: string
   value: ""
 

--- a/src/colibri/config/helpers/configs/tools/general.yml
+++ b/src/colibri/config/helpers/configs/tools/general.yml
@@ -51,6 +51,11 @@ waveform_viewer:
     surfer: "Surfer"
   value: "tool"
 
+vaporview_import_signals:
+  description: "Import signals automatically in VaporView."
+  type: boolean
+  value: true
+
 gtkwave_installation_path:
   description: "GTKWave installation directory."
   type: string

--- a/src/colibri/config/helpers/configs/tools/general.yml
+++ b/src/colibri/config/helpers/configs/tools/general.yml
@@ -51,7 +51,7 @@ waveform_viewer:
     surfer: "Surfer"
   value: "tool"
 
-vaporview_import_signals:
+vaporview_load_all_signals:
   description: "Import signals automatically in VaporView."
   type: boolean
   value: true

--- a/src/colibri/config/helpers/configs/tools/general.yml
+++ b/src/colibri/config/helpers/configs/tools/general.yml
@@ -42,12 +42,13 @@ execution_mode:
   value: "cmd"
 
 waveform_viewer:
-  description: "Select the waveform viewer. For GTKWave you need to install it."
+  description: "Select the waveform viewer. For GTKWave/Surfer you need to install it."
   type: select
   options:
     tool: "Tool GUI"
     vaporView: "VaporView"
     gtkwave: "GTKWave"
+    surfer: "Surfer"
   value: "tool"
 
 gtkwave_installation_path:
@@ -57,5 +58,15 @@ gtkwave_installation_path:
 
 gtkwave_extra_arguments:
   description: "Extra arguments passed to GTKwave. E.g: --script=script.tcl"
+  type: string
+  value: ""
+
+surfer_installation_path:
+  description: "Surfer installation directory."
+  type: string
+  value: ""
+
+surfer_extra_arguments:
+  description: "Extra arguments passed to Surfer. E.g: --script=script.tcl"
   type: string
   value: ""

--- a/src/colibri/config/helpers/configs/tools/symbiflow.yml
+++ b/src/colibri/config/helpers/configs/tools/symbiflow.yml
@@ -11,11 +11,11 @@ part:
   type: string
   value: ""
 vendor:
-  description: "Target architecture. Currently only “xilinx” is supported."
+  description: "Target architecture. Currently only \"xilinx\" is supported."
   type: string
   value: ""
 pnr:
-  description: "Place and Route tool. Currently only “vpr” is supported."
+  description: "Place and Route tool. Currently only \"vpr\" is supported."
   type: select
   options:
     vpr: "VPR"

--- a/src/colibri/config/helpers/configs/tools/verible.yml
+++ b/src/colibri/config/helpers/configs/tools/verible.yml
@@ -15,6 +15,6 @@ installation_path:
 #   type: array
 #   value: []
 # rules:
-#   description: "What rules to use. Prefix a rule name with “-” to disable it."
+#   description: "What rules to use. Prefix a rule name with \"-\" to disable it."
 #   type: array
 #   value: []

--- a/src/colibri/config/helpers/generate_web.py
+++ b/src/colibri/config/helpers/generate_web.py
@@ -66,5 +66,5 @@ with open(template_path) as file:
     )
 
 output_path = os.path.join(os.path.dirname(__file__), "..", "config_web.ts")
-with open(output_path, mode="w") as file:
+with open(output_path, mode="w", encoding="utf-8") as file:
     file.write(template)

--- a/src/colibri/config/web_config.html
+++ b/src/colibri/config/web_config.html
@@ -1975,10 +1975,10 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-checkbox">
-                            <input type="checkbox" id="tools-general-vaporview_import_signals">
-                            <label class="setting-checkbox-label" for="tools-general-vaporview_import_signals">
+                            <input type="checkbox" id="tools-general-vaporview_load_all_signals">
+                            <label class="setting-checkbox-label" for="tools-general-vaporview_load_all_signals">
                                 Import signals automatically in VaporView.
-                                <span class="markConfig" id="mark_tools-general-vaporview_import_signals"></span>
+                                <span class="markConfig" id="mark_tools-general-vaporview_load_all_signals"></span>
                             </label>
                         </div>
                     </div>
@@ -5988,8 +5988,8 @@ body.vscode-high-contrast {
     config["tools"]["general"]["execution_mode"] = element_value
     element_value = document.getElementById("tools-general-waveform_viewer").value;
     config["tools"]["general"]["waveform_viewer"] = element_value
-    element_value = document.getElementById("tools-general-vaporview_import_signals").checked;
-    config["tools"]["general"]["vaporview_import_signals"] = element_value
+    element_value = document.getElementById("tools-general-vaporview_load_all_signals").checked;
+    config["tools"]["general"]["vaporview_load_all_signals"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_installation_path").value;
     config["tools"]["general"]["gtkwave_installation_path"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_extra_arguments").value;
@@ -7003,8 +7003,8 @@ body.vscode-high-contrast {
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["waveform_viewer"] !== undefined) {
         document.getElementById("tools-general-waveform_viewer").value = config["tools"]["general"]["waveform_viewer"];
     }
-    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
-        document.getElementById("tools-general-vaporview_import_signals").checked = config["tools"]["general"]["vaporview_import_signals"];
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_load_all_signals"] !== undefined) {
+        document.getElementById("tools-general-vaporview_load_all_signals").checked = config["tools"]["general"]["vaporview_load_all_signals"];
     }
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
         document.getElementById("tools-general-gtkwave_installation_path").value = config["tools"]["general"]["gtkwave_installation_path"];
@@ -8191,10 +8191,10 @@ body.vscode-high-contrast {
     }
     document.getElementById("mark_tools-general-waveform_viewer").innerHTML = mark;
     mark = "";
-    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_load_all_signals"] !== undefined) {
       mark = MODIFIEDMSG;
     }
-    document.getElementById("mark_tools-general-vaporview_import_signals").innerHTML = mark;
+    document.getElementById("mark_tools-general-vaporview_load_all_signals").innerHTML = mark;
     mark = "";
     if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
       mark = MODIFIEDMSG;

--- a/src/colibri/config/web_config.html
+++ b/src/colibri/config/web_config.html
@@ -1959,7 +1959,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Select the waveform viewer. For GTKWave you need to install it.
+                            Select the waveform viewer. For GTKWave/Surfer you need to install it.
                             <span class="markConfig" id="mark_tools-general-waveform_viewer"></span>
                         </div>
                         <div class="select-container">
@@ -1967,7 +1967,19 @@ body.vscode-high-contrast {
                                       <option value='tool'>Tool GUI</option>
                                       <option value='vaporView'>VaporView</option>
                                       <option value='gtkwave'>GTKWave</option>
+                                      <option value='surfer'>Surfer</option>
                             </select>
+                        </div>
+                    </div>
+                  
+                  
+                    <div class="setting-item">
+                        <div class="setting-checkbox">
+                            <input type="checkbox" id="tools-general-vaporview_import_signals">
+                            <label class="setting-checkbox-label" for="tools-general-vaporview_import_signals">
+                                Import signals automatically in VaporView.
+                                <span class="markConfig" id="mark_tools-general-vaporview_import_signals"></span>
+                            </label>
                         </div>
                     </div>
                   
@@ -1990,13 +2002,31 @@ body.vscode-high-contrast {
                     </div>
                   
                   
+                    <div class="setting-item">
+                        <div class="setting-item-label">
+                            Surfer installation directory.
+                            <span class="markConfig" id="mark_tools-general-surfer_installation_path"></span>
+                        </div>
+                            <input class="setting-input-box" id="tools-general-surfer_installation_path" value="">
+                    </div>
+                  
+                  
+                    <div class="setting-item">
+                        <div class="setting-item-label">
+                            Extra arguments passed to Surfer. E.g: --script=script.tcl
+                            <span class="markConfig" id="mark_tools-general-surfer_extra_arguments"></span>
+                        </div>
+                            <input class="setting-input-box" id="tools-general-surfer_extra_arguments" value="">
+                    </div>
+                  
+                  
                   
             </div>
             <div class="settings-section" id="tools-quartus">
                 <div class="settings-group-title-label">
                     Tools: Intel@ Quartus@ Prime
                 </div>
-                <div class="settings-group-description">The intuitive high-performance design environment. From design entry and synthesis to optimization, verification, and simulation, Intel® Quartus® Prime Design Software unlocks increased capabilities on devices with multi-million logic elements, providing designers with the ideal platform to meet next-generation design opportunities.</div>
+                <div class="settings-group-description">The intuitive high-performance design environment. From design entry and synthesis to optimization, verification, and simulation, IntelÂ® QuartusÂ® Prime Design Software unlocks increased capabilities on devices with multi-million logic elements, providing designers with the ideal platform to meet next-generation design opportunities.</div>
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
@@ -2238,7 +2268,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Any argument to be passed to the “first” invocation of a simulator that runs via a TCL script. One motivating usage is to pass -noautoldlibpath to Questa to prevent it from loading the out-of-date libraries it ships with. Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator.
+                            Any argument to be passed to the "first" invocation of a simulator that runs via a TCL script. One motivating usage is to pass -noautoldlibpath to Questa to prevent it from loading the out-of-date libraries it ships with. Used by Aldec Riviera-PRO and Mentor Graphics Questa simulator.
                             <span class="markConfig" id="mark_tools-cocotb-run_args"></span>
                         </div>
                             <input class="setting-input-box" id="tools-cocotb-run_args" value="">
@@ -3418,7 +3448,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            A list of the .sby file’s tasks to run. Passed on the sby command line..
+                            A list of the .sby fileâ€™s tasks to run. Passed on the sby command line..
                             <span class="markConfig" id="mark_tools-symbiyosys-tasknames"></span>
                         </div>
                         <div class="setting-item-description">Comma separated values</div>
@@ -3462,7 +3492,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Target architecture. Currently only “xilinx” is supported.
+                            Target architecture. Currently only "xilinx" is supported.
                             <span class="markConfig" id="mark_tools-symbiflow-vendor"></span>
                         </div>
                             <input class="setting-input-box" id="tools-symbiflow-vendor" value="">
@@ -3471,7 +3501,7 @@ body.vscode-high-contrast {
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
-                            Place and Route tool. Currently only “vpr” is supported.
+                            Place and Route tool. Currently only "vpr" is supported.
                             <span class="markConfig" id="mark_tools-symbiflow-pnr"></span>
                         </div>
                         <div class="select-container">
@@ -4804,7 +4834,7 @@ body.vscode-high-contrast {
                 <div class="settings-group-title-label">
                     Tools: Active-HDL
                 </div>
-                <div class="settings-group-description">Active-HDL™ is a Windows based, integrated FPGA Design Creation and Simulation solution for team-based environments.</div>
+                <div class="settings-group-description">Active-HDLâ„¢ is a Windows based, integrated FPGA Design Creation and Simulation solution for team-based environments.</div>
                   
                     <div class="setting-item">
                         <div class="setting-item-label">
@@ -5958,10 +5988,16 @@ body.vscode-high-contrast {
     config["tools"]["general"]["execution_mode"] = element_value
     element_value = document.getElementById("tools-general-waveform_viewer").value;
     config["tools"]["general"]["waveform_viewer"] = element_value
+    element_value = document.getElementById("tools-general-vaporview_import_signals").checked;
+    config["tools"]["general"]["vaporview_import_signals"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_installation_path").value;
     config["tools"]["general"]["gtkwave_installation_path"] = element_value
     element_value = document.getElementById("tools-general-gtkwave_extra_arguments").value;
     config["tools"]["general"]["gtkwave_extra_arguments"] = element_value
+    element_value = document.getElementById("tools-general-surfer_installation_path").value;
+    config["tools"]["general"]["surfer_installation_path"] = element_value
+    element_value = document.getElementById("tools-general-surfer_extra_arguments").value;
+    config["tools"]["general"]["surfer_extra_arguments"] = element_value
     config["tools"]["quartus"] = {}
     element_value = document.getElementById("tools-quartus-installation_path").value;
     config["tools"]["quartus"]["installation_path"] = element_value
@@ -6967,11 +7003,20 @@ body.vscode-high-contrast {
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["waveform_viewer"] !== undefined) {
         document.getElementById("tools-general-waveform_viewer").value = config["tools"]["general"]["waveform_viewer"];
     }
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
+        document.getElementById("tools-general-vaporview_import_signals").checked = config["tools"]["general"]["vaporview_import_signals"];
+    }
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
         document.getElementById("tools-general-gtkwave_installation_path").value = config["tools"]["general"]["gtkwave_installation_path"];
     }
     if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_extra_arguments"] !== undefined) {
         document.getElementById("tools-general-gtkwave_extra_arguments").value = config["tools"]["general"]["gtkwave_extra_arguments"];
+    }
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_installation_path"] !== undefined) {
+        document.getElementById("tools-general-surfer_installation_path").value = config["tools"]["general"]["surfer_installation_path"];
+    }
+    if (config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_extra_arguments"] !== undefined) {
+        document.getElementById("tools-general-surfer_extra_arguments").value = config["tools"]["general"]["surfer_extra_arguments"];
     }
     if (config["tools"] && config["tools"]["quartus"] && config["tools"]["quartus"]["installation_path"] !== undefined) {
         document.getElementById("tools-quartus-installation_path").value = config["tools"]["quartus"]["installation_path"];
@@ -8146,6 +8191,11 @@ body.vscode-high-contrast {
     }
     document.getElementById("mark_tools-general-waveform_viewer").innerHTML = mark;
     mark = "";
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["vaporview_import_signals"] !== undefined) {
+      mark = MODIFIEDMSG;
+    }
+    document.getElementById("mark_tools-general-vaporview_import_signals").innerHTML = mark;
+    mark = "";
     if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["gtkwave_installation_path"] !== undefined) {
       mark = MODIFIEDMSG;
     }
@@ -8155,6 +8205,16 @@ body.vscode-high-contrast {
       mark = MODIFIEDMSG;
     }
     document.getElementById("mark_tools-general-gtkwave_extra_arguments").innerHTML = mark;
+    mark = "";
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_installation_path"] !== undefined) {
+      mark = MODIFIEDMSG;
+    }
+    document.getElementById("mark_tools-general-surfer_installation_path").innerHTML = mark;
+    mark = "";
+    if (projectName !== undefined && config["tools"] && config["tools"]["general"] && config["tools"]["general"]["surfer_extra_arguments"] !== undefined) {
+      mark = MODIFIEDMSG;
+    }
+    document.getElementById("mark_tools-general-surfer_extra_arguments").innerHTML = mark;
     mark = "";
     if (projectName !== undefined && config["tools"] && config["tools"]["quartus"] && config["tools"]["quartus"]["installation_path"] !== undefined) {
       mark = MODIFIEDMSG;

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -65,7 +65,12 @@ export class Comander {
         if (config.tools.general.waveform_viewer == e_tools_general_waveform_viewer.vaporView) {
             const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
             if (extension && extension.isActive) {
-                await vscode.commands.executeCommand('vaporview.openFile', args);
+                let vaporview_args = {
+                    uri: args,
+                    loadAll: false,
+                    maxSignals: 64
+                };
+                await vscode.commands.executeCommand('vaporview.openFile', vaporview_args);
                 return;
             }
             vscode.window.showInformationMessage(`VaporView not available or not active. Defaulting to GTKWave.`);

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -18,7 +18,7 @@
 // along with TerosHDL.  If not, see <https://www.gnu.org/licenses/>.
 
 import * as vscode from 'vscode';
-import {spawn} from 'child_process';
+import { spawn } from 'child_process';
 import { Base_webview } from './web';
 import { Multi_project_manager } from 'colibri/project_manager/multi_project_manager';
 import * as path_lib from 'path';
@@ -62,34 +62,34 @@ export class Comander {
         const file_path = args.fsPath;
         globalLogger.info(`Opening the waveform: ${file_path}`);
 
-        const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
-        if (config.tools.general.waveform_viewer !== e_tools_general_waveform_viewer.gtkwave) {
+        if (config.tools.general.waveform_viewer == e_tools_general_waveform_viewer.vaporView) {
+            const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
             if (extension && extension.isActive) {
                 await vscode.commands.executeCommand('vaporview.openFile', args);
                 return;
             }
-            else if (config.tools.general.waveform_viewer !== e_tools_general_waveform_viewer.vaporView) {
-                vscode.window.showInformationMessage(`Waveform viewer not available or not active.`);
-            }
+            vscode.window.showInformationMessage(`VaporView not available or not active. Defaulting to GTKWave.`);
         }
 
-        let gtkwave_binary = "gtkwave";
+        const use_surfer = config.tools.general.waveform_viewer == e_tools_general_waveform_viewer.surfer;
+
+        let waveviewer_binary = use_surfer ? "surfer" : "gtkwave";
         const os_i = get_os();
         if (os_i === OS.WINDOWS) {
-            gtkwave_binary = "gtkwave.exe";
+            waveviewer_binary = use_surfer ? "surfer.exe" : "gtkwave.exe";
         }
 
-        let gtkwave_path = "";
-        let base_path = config.tools.general.gtkwave_installation_path;
+        let waveviewer_path = "";
+        let base_path = use_surfer ? config.tools.general.surfer_installation_path : config.tools.general.gtkwave_installation_path;
         if (base_path !== "") {
-            gtkwave_path = path_lib.join(base_path, gtkwave_binary);
+            waveviewer_path = path_lib.join(base_path, waveviewer_binary);
         }
         else {
-            gtkwave_path = gtkwave_binary;
+            waveviewer_path = waveviewer_binary;
         }
-        const extra_arguments = config.tools.general.gtkwave_extra_arguments;
+        const extra_arguments = use_surfer ? config.tools.general.surfer_extra_arguments : config.tools.general.gtkwave_extra_arguments;
 
-        let command = `${gtkwave_path} ${file_path} ${extra_arguments}`;
+        let command = `${waveviewer_path} ${file_path} ${extra_arguments}`;
         // shelljs.exec(command, { async: true });
         spawn(command, {
             shell: true,

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -67,7 +67,7 @@ export class Comander {
             if (extension && extension.isActive) {
                 let vaporview_args = {
                     uri: args,
-                    loadAll: config.tools.general.vaporview_import_signals,
+                    loadAll: config.tools.general.vaporview_load_all_signals,
                     maxSignals: 64
                 };
                 await vscode.commands.executeCommand('vaporview.openFile', vaporview_args);

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -97,7 +97,7 @@ export class Comander {
         let command = `${waveviewer_path} ${file_path} ${extra_arguments}`;
         // shelljs.exec(command, { async: true });
         spawn(command, {
-            shell: true,
+            shell: false,
             stdio: 'inherit'
         });
     }

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -67,7 +67,7 @@ export class Comander {
             if (extension && extension.isActive) {
                 let vaporview_args = {
                     uri: args,
-                    loadAll: false,
+                    loadAll: config.tools.general.vaporview_import_signals,
                     maxSignals: 64
                 };
                 await vscode.commands.executeCommand('vaporview.openFile', vaporview_args);

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -63,8 +63,10 @@ export class Comander {
         globalLogger.info(`Opening the waveform: ${file_path}`);
 
         if (config.tools.general.waveform_viewer == e_tools_general_waveform_viewer.vaporView) {
-            const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
-            if (extension && extension.isActive) {
+            const extension = vscode.extensions.getExtension('lramseyer.vaporview');
+            if (extension) {
+                if (!extension.isActive)
+                    await extension.activate();
                 let vaporview_args = {
                     uri: args,
                     loadAll: config.tools.general.vaporview_load_all_signals,

--- a/src/teroshdl/features/configChecker/externalTools.ts
+++ b/src/teroshdl/features/configChecker/externalTools.ts
@@ -105,19 +105,13 @@ export async function checkExternalToolManager(currentConfig: e_config) {
             isOk = false;
         }
     } else if (waveformViewer == e_tools_general_waveform_viewer.vaporView) {
-        const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
+        const extension = vscode.extensions.getExtension('lramseyer.vaporview');
         let configOk: boolean = false;
         // Mock a BinaryCheck result for the extension.
         let messageList = [`🔎 Searching for the VaporView extension in vscode`];
         if (extension) {
             messageList.push(`✅ VaporView extension found in vscode`);
-            if (extension.isActive) {
-                configOk = true;
-                messageList.push(`✅ VaporView extension enabled in vscode`);
-            }
-            else {
-                messageList.push(`❌ VaporView extension not enabled in vscode`);
-            }
+            configOk = true;
         } else {
             messageList.push(`❌ VaporView extension not installed in vscode`);
         }

--- a/src/teroshdl/features/configChecker/externalTools.ts
+++ b/src/teroshdl/features/configChecker/externalTools.ts
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with TerosHDL.  If not, see <https://www.gnu.org/licenses/>.
 
+import * as vscode from 'vscode';
+import { BinaryCheck } from 'colibri/toolChecker/utils';
 import {
     e_config,
     e_tools_general_execution_mode,
@@ -51,7 +53,7 @@ export async function checkExternalToolManager(currentConfig: e_config) {
     // Default to '--version' if no custom argument is specified
     const versionArgument = customVersionArgs[selectedTool] || '--version';
 
-    let binaryName : string | string[] =
+    let binaryName: string | string[] =
         selectedTool === e_tools_general_select_tool.rivierapro ? ['rivierapro', 'riviera'] : selectedTool;
     binaryName = binaryName === e_tools_general_select_tool.icarus ? 'iverilog' : binaryName;
 
@@ -79,9 +81,15 @@ export async function checkExternalToolManager(currentConfig: e_config) {
             'GTKWave waveform viewer will be opened after the simulation. Make sure that the GTKWave is correctly configured.';
     } else if (waveformViewer === e_tools_general_waveform_viewer.tool) {
         extraMsg = 'Built-in tool waveform viewer will be opened after the simulation if it is available.';
+    } else if (waveformViewer === e_tools_general_waveform_viewer.vaporView) {
+        extraMsg =
+            'VaporView waveform viewer will be opened after the simulation. Make sure the extension is available.';
+    } else if (waveformViewer === e_tools_general_waveform_viewer.surfer) {
+        extraMsg =
+            'Surfer waveform viewer will be opened after the simulation. Make sure Surfer is correctly configured.';
     }
     msg += `${INTROICON} Waveform viewer: ${waveformViewer.toLocaleUpperCase()}. ${extraMsg}\n`;
-    // Check GTKwave
+    // Check GTKwave or Surfer
     if (waveformViewer === e_tools_general_waveform_viewer.gtkwave) {
         const gtkwavePath = currentConfig.tools.general.gtkwave_installation_path;
         result = await checkBinary('GTKWave', gtkwavePath, 'gtkwave', ['--version']);
@@ -89,6 +97,40 @@ export async function checkExternalToolManager(currentConfig: e_config) {
         if (!result.successfulConfig) {
             isOk = false;
         }
+    } else if (waveformViewer === e_tools_general_waveform_viewer.surfer) {
+        const surferPath = currentConfig.tools.general.surfer_installation_path;
+        result = await checkBinary('Surfer', surferPath, 'surfer', ['--version']);
+        msg = appendMsg(result, msg, 'Wavefrom Viewer');
+        if (!result.successfulConfig) {
+            isOk = false;
+        }
+    } else if (waveformViewer == e_tools_general_waveform_viewer.vaporView) {
+        const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
+        let configOk: boolean = false;
+        // Mock a BinaryCheck result for the extension.
+        let messageList = [`🔎 Searching for the VaporView extension in vscode`];
+        if (extension) {
+            messageList.push(`✅ VaporView extension found in vscode`);
+            if (extension.isActive) {
+                configOk = true;
+                messageList.push(`✅ VaporView extension enabled in vscode`);
+            }
+            else {
+                messageList.push(`❌ VaporView extension not enabled in vscode`);
+            }
+        } else {
+            messageList.push(`❌ VaporView extension not installed in vscode`);
+        }
+        const result: BinaryCheck = {
+            displayName: "Surfer",
+            binaryPath: "N/A",
+            messageList: messageList,
+            successfulFind: extension !== undefined,
+            successfulConfig: configOk,
+        };
+        // Add results
+        msg = appendMsg(result, msg, 'Wavefrom Viewer');
+        isOk = configOk;
     }
 
     msg += '\n';


### PR DESCRIPTION
Implements #825 
Adds support for [Standalone Surfer](https://surfer-project.org/) and [VaporView](https://marketplace.visualstudio.com/items?itemName=lramseyer.vaporview) waveform viewers.

#### Notes:
- The `loadAll` attribute used by VaporView (`vaporview_load_all_signals` setting) does not load all signals, despite correct usage. This may be a bug on VaporView's end.
- It is unclear to me how to use vscode's api to open waveforms using the [vscode extension of Surfer](https://marketplace.visualstudio.com/items?itemName=surfer-project.surfer).
- Tested by compiling under Windows, with local quickfixed to make compilation possible. Should be tested by maintainers.