### PR TITLE
Update waveform viewer UI text and make Viewer selection explicit (no GTKWave fallback)

### DIFF
--- a/src/colibri/config/config_web.ts
+++ b/src/colibri/config/config_web.ts
@@ -1985,7 +1985,7 @@ body.vscode-high-contrast {
                         </div>
                         <div class="select-container">
                             <select class="setting-select-box" id="tools-general-waveform_viewer">
-                                      <option value='tool'>Tool GUI</option>
+                                      <option value='tool'>Simulator's built-in waveform viewer</option>
                                       <option value='vaporView'>VaporView</option>
                                       <option value='gtkwave'>GTKWave</option>
                             </select>

--- a/src/colibri/config/helpers/configs/tools/general.yml
+++ b/src/colibri/config/helpers/configs/tools/general.yml
@@ -45,7 +45,7 @@ waveform_viewer:
   description: "Select the waveform viewer. For GTKWave you need to install it."
   type: select
   options:
-    tool: "Tool GUI"
+    tool: "Simulator's built-in waveform viewer"
     vaporView: "VaporView"
     gtkwave: "GTKWave"
   value: "tool"

--- a/src/colibri/config/web_config.html
+++ b/src/colibri/config/web_config.html
@@ -1964,7 +1964,7 @@ body.vscode-high-contrast {
                         </div>
                         <div class="select-container">
                             <select class="setting-select-box" id="tools-general-waveform_viewer">
-                                      <option value='tool'>Tool GUI</option>
+                                      <option value='tool'>Simulator's built-in waveform viewer</option>
                                       <option value='vaporView'>VaporView</option>
                                       <option value='gtkwave'>GTKWave</option>
                             </select>

--- a/src/teroshdl/features/comander/run.ts
+++ b/src/teroshdl/features/comander/run.ts
@@ -62,39 +62,65 @@ export class Comander {
         const file_path = args.fsPath;
         globalLogger.info(`Opening the waveform: ${file_path}`);
 
+        // Decide which viewer to open explicitly based on configuration.
         const extension = await vscode.extensions.getExtension('lramseyer.vaporview');
-        if (config.tools.general.waveform_viewer !== e_tools_general_waveform_viewer.gtkwave) {
+
+        // 1) VaporView (extension)
+        if (config.tools.general.waveform_viewer === e_tools_general_waveform_viewer.vaporView) {
             if (extension && extension.isActive) {
                 await vscode.commands.executeCommand('vaporview.openFile', args);
                 return;
             }
-            else if (config.tools.general.waveform_viewer !== e_tools_general_waveform_viewer.vaporView) {
-                vscode.window.showInformationMessage(`Waveform viewer not available or not active.`);
+            else {
+                vscode.window.showInformationMessage(`VaporView extension not available or not active.`);
+                return;
             }
         }
 
-        let gtkwave_binary = "gtkwave";
-        const os_i = get_os();
-        if (os_i === OS.WINDOWS) {
-            gtkwave_binary = "gtkwave.exe";
+        // 2) Tool GUI (simulator built-in or tool-provided viewer)
+        if (config.tools.general.waveform_viewer === e_tools_general_waveform_viewer.tool) {
+            const selectedTool = config.tools.general.select_tool;
+            // Typical implementations:
+            // - For simulators that open their own GUI (ModelSim/Questa, Vivado, etc.)
+            //   ensure the simulator was launched with GUI flags during the run.
+            // - For simulators that generate VCD/FSDB/LXT files, open the file with
+            //   the appropriate viewer (or a dedicated extension).
+            // Here we show an informational message and log the intent.
+            globalLogger.info(`Tool GUI requested for simulator: ${selectedTool}. No handler implemented.`);
+            vscode.window.showInformationMessage(`Tool GUI selected for '${selectedTool}'. No handler implemented.`);
+            return;
         }
 
-        let gtkwave_path = "";
-        let base_path = config.tools.general.gtkwave_installation_path;
-        if (base_path !== "") {
-            gtkwave_path = path_lib.join(base_path, gtkwave_binary);
+        // 3) GTKWave (external binary)
+        if (config.tools.general.waveform_viewer === e_tools_general_waveform_viewer.gtkwave) {
+            let gtkwave_binary = "gtkwave";
+            const os_i = get_os();
+            if (os_i === OS.WINDOWS) {
+                gtkwave_binary = "gtkwave.exe";
+            }
+
+            let gtkwave_path = "";
+            let base_path = config.tools.general.gtkwave_installation_path;
+            if (base_path !== "") {
+                gtkwave_path = path_lib.join(base_path, gtkwave_binary);
+            }
+            else {
+                gtkwave_path = gtkwave_binary;
+            }
+            const extra_arguments = config.tools.general.gtkwave_extra_arguments;
+
+            let command = `${gtkwave_path} ${file_path} ${extra_arguments}`;
+            // shelljs.exec(command, { async: true });
+            spawn(command, {
+                shell: true,
+                stdio: 'inherit'
+            });
         }
         else {
-            gtkwave_path = gtkwave_binary;
+            // If the user selected 'tool' (simulator) or nothing matched, do not
+            // attempt to run GTKWave implicitly.
+            vscode.window.showInformationMessage(`No external waveform viewer selected or available.`);
         }
-        const extra_arguments = config.tools.general.gtkwave_extra_arguments;
-
-        let command = `${gtkwave_path} ${file_path} ${extra_arguments}`;
-        // shelljs.exec(command, { async: true });
-        spawn(command, {
-            shell: true,
-            stdio: 'inherit'
-        });
     }
 
     private open_webview(args: string, webview: Base_webview) {


### PR DESCRIPTION
fix #826 

- Clarify the meaning of the "Tool GUI" waveform-viewer option in the UI, making the behavior more intuitive when opening waveforms.
- Remove the implicit fallback that launched GTKWave for any non-GTKWave selection
- Add a clear log for the simulator-built-in viewer option (simulator handling can be implemented later).