### PR TITLE
Fix Vivado detection on Windows for unwrapped installations (Fix #821)

### DIFF
--- a/src/colibri/linter/vivado.ts
+++ b/src/colibri/linter/vivado.ts
@@ -25,6 +25,7 @@ import { LANGUAGE } from "../common/general";
 import { Base_linter } from "./base_linter";
 import * as common from "./common";
 import * as path_lib from "path";
+import { BinaryCheck, checkBinary } from "colibri/toolChecker/utils";
 
 export class Vivado extends Base_linter {
     binary = "vivado";
@@ -33,6 +34,13 @@ export class Vivado extends Base_linter {
 
     constructor() {
         super();
+    }
+
+    public async checkLinterConfiguration(installationPath: string): Promise<BinaryCheck> {
+        // Vivado installations can expose either wrapper binaries (vivado) or
+        // direct lint binaries (xvhdl/xvlog), depending on the configured folder.
+        const binaryCandidates = ["xvhdl", "xvlog", "vivado"];
+        return await checkBinary(this.constructor.name, installationPath, binaryCandidates, this.argumentToCheck);
     }
 
     public set_binary(file: string) {


### PR DESCRIPTION
## Summary
This PR fixes Vivado linter detection on Windows when the configured installation path points to unwrapped binaries and vivado.exe is not directly available.

## Problem
In issue #821, TerosHDL failed Vivado configuration checks for valid Windows installations (Vivado 2025.1), reporting Vivado not found even though lint-capable binaries existed in the configured path.

## Root cause
The configuration check only validated vivado, while actual lint execution may rely on xvhdl/xvlog depending on language and installation layout.

## What changed
In src/colibri/linter/vivado.ts, this PR overrides checkLinterConfiguration to validate against a binary candidate list:
- xvhdl
- xvlog
- vivado

This uses existing binary checker utilities and keeps the rest of linter behavior unchanged.

## Validation
- TypeScript compile completed successfully (npm run compile).

## Impact
Users configuring Vivado Windows paths that contain xvhdl/xvlog (but not a directly invokable vivado binary) should now pass linter configuration checks.

