### PR TITLE
remove the netlist viewer of VHDL

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
                 }
                         
                 ,{
-                    "when": "resourceLangId == verilog || resourceLangId == systemverilog || resourceLangId == vhdl",
+                    "when": "resourceLangId == verilog || resourceLangId == systemverilog",
                     "command": "teroshdl.netlist.viewer",
                     "group": "navigation"
                 }


### PR DESCRIPTION
    Because netlist  viewer doesn't work well in VHDL, it is better to remove this option only for VHDL, until this option works