### PR TITLE
Improve hierarchy

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
                 }
                         
                 ,{
-                    "when": "resourceLangId == verilog || resourceLangId == systemverilog || resourceLangId == vhdl",
+                    "when": "resourceLangId == verilog || resourceLangId == systemverilog",
                     "command": "teroshdl.netlist.viewer",
                     "group": "navigation"
                 }

--- a/snippets/vhdl/vhdl.json
+++ b/snippets/vhdl/vhdl.json
@@ -419,7 +419,7 @@
 	},
 	"Others": {
 		"prefix": ["others"],
-		"body": [ "(others => ${1:<value>})${2| ,;|}$0" ],
+		"body": [ "(others=>${1:<value>})${2| ,;|}$0" ],
 		"description": "others declaration"
 	},
 	"Package": {

--- a/snippets/vhdl/vhdl.json
+++ b/snippets/vhdl/vhdl.json
@@ -86,6 +86,19 @@
 		],
 		"description": "case statement"
 	},
+	"FSM definition": {
+		"prefix": "fsmdef",
+		"body": [
+			"--! ${1:Comment}",
+			"type ${2:fsm_type_name} is (",
+			"\t$3",
+			");",
+			"--! ${4:State definition}",
+			"signal ${5:state_definition} : $2;",
+			"$0"
+		],
+		"description": "definition of the FSM"
+	},
 	"FSM example generate": {
 		"prefix": "fsm",
 		"body": [
@@ -156,7 +169,8 @@
 	"Constant": {
 		"prefix": "constant",
 		"body": [
-			"constant ${1:<name>} : ${2:<type>} := ${3:<default_value>};",
+			"--! ${1:Comment}",
+			"constant ${2:<name>} : ${3:<type>} := ${4:<default_value>};",
 			"$0"
 		],
 		"description": "constant declaration"
@@ -164,10 +178,29 @@
 	"Signal": {
 		"prefix": "signal",
 		"body": [
-			"signal ${1:<name>} : ${2:<type>} := ${3:<default_value>};",
+			"--! ${1:Comment}",
+			"signal ${2:<name>} : ${3:<type>};",
 			"$0"
 		],
 		"description": "signal declaration"
+	},
+	"Counter integer": {
+		"prefix": "counterinteger",
+		"body": [
+			"--! ${1:Comment}",
+			"signal ${2:<name>} : integer range 0 to ${3:<type>};",
+			"$0"
+		],
+		"description": "counter declaration"
+	},
+	"Signal previous value": {
+		"prefix": "signalvalue",
+		"body": [
+			"--! ${1:Comment}",
+			"signal ${2:<name>} : ${3:<type>} := ${4:<default_value>};",
+			"$0"
+		],
+		"description": "signal declaration with previous value"
 	},
 	"Configuration": {
 		"prefix": "configuration",
@@ -364,6 +397,7 @@
 		"prefix": "library",
 		"body": [
 			"library ${1:ieee};",
+			"",
 			"$0"
 		],
 		"description": "library declaration"
@@ -375,9 +409,21 @@
 			"use ieee.std_logic_1164.all;",
 			"use ieee.numeric_std.all;",
 			"use ieee.math_real.all;",
+			"",
 			"$0"
 		],
 		"description": "common IEEE libraries declaration"
+	},
+	"Library Numeric": {
+		"prefix": "librarynumeric",
+		"body": [
+			"library ieee;",
+			"use ieee.std_logic_1164.all;",
+			"use ieee.numeric_std.all;",
+			"",
+			"$0"
+		],
+		"description": "numeric IEEE libraries declaration"
 	},
 	"Library IEEE 2008": {
 		"prefix": "libraryieee",
@@ -385,6 +431,7 @@
 			"library ieee;",
 			"context ieee.ieee_std_context;",
 			"use ieee.math_real.all;",
+			"",
 			"$0"
 		],
 		"description": "common IEEE libraries declaration with 2008 standard context (vhdl 2008)"
@@ -394,6 +441,7 @@
 		"body": [
 			"library std;",
 			"use std.textio.all;",
+			"",
 			"$0"
 		],
 		"description": "TextIO library declaration"
@@ -479,54 +527,78 @@
 	"Process Asynchronous": {
 		"prefix": ["aproc", "processasync"],
 		"body": [
-			"process (${1:clk}, ${2:reset})",
+			"\r--! ${1:Comment}",
+			"${2:PROCESS_NAME} : process (${3:clk}, ${4:reset})",
 			"begin",
-			"\tif $2 = ${3|'1','0'|} then",
+			"\tif $4 = ${5|'1','0'|} then",
 			"\t\t$0",
-			"\telsif ${4|rising_edge,falling_edge|}($1) then",
+			"\telsif ${6|rising_edge,falling_edge|}($3) then",
 			"\t\t",
 			"\tend if;",
-			"end process;"
+			"end process $2;"
 		],
 		"description": "asynchronous process block"
 	},
 	"Process Synchronous": {
 		"prefix": ["sproc", "processsync"],
 		"body": [
-			"process (${1:clk})",
+			"\r--! ${1:Comment}",
+			"${2:PROCESS_NAME} : process (${3:clk})",
 			"begin",
-			"\tif ${2|rising_edge,falling_edge|}($1) then",
-			"\t\tif ${3:reset} = ${4|'1','0'|} then",
+			"\tif ${4|rising_edge,falling_edge|}($3) then",
+			"\t\tif ${5:reset} = ${6|'1','0'|} then",
 			"\t\t\t$0",
 			"\t\telse",
 			"\t\t\t",
 			"\t\tend if;",
 			"\tend if;",
-			"end process;"
+			"end process $2;"
 		],
 		"description": "clocked process block"
 	},
 	"Process Clocked": {
 		"prefix": ["cproc", "processclk"],
 		"body": [
-			"process (${1:clk})",
+			"\r--! ${1:Comment}",
+			"${2:PROCESS_NAME} : process (${3:clk})",
 			"begin",
-			"\tif ${2|rising_edge,falling_edge|}($1) then",
+			"\tif ${4|rising_edge,falling_edge|}($3) then",
 			"\t\t$0",
 			"\tend if;",
-			"end process;"
+			"end process $2;"
 		],
 		"description": "clocked process block"
 	},
 	"Process Combinatorial": {
 		"prefix": "process",
 		"body": [
-			"process (${1:all})",
+			"\r--! ${1:Comment}",
+			"${2:PROCESS_NAME} : process (${3:all})",
 			"begin",
+			"\t$0",
+			"end process $2;"
+		],
+		"description": "combinatorial process block"
+	},
+	"Process All": {
+		"prefix": "processall",
+		"body": [
+			"\r--! ${1:Comment}",
+			"${2:PROCESS_NAME} : process (all)",
+			"begin",
+			"\t$0",
+			"end process $2;"
+		],
+		"description": "process all block"
+	},
+	"Process Testbench": {
+		"prefix": "processbegin",
+		"body": [
+			"process begin",
 			"\t$0",
 			"end process;"
 		],
-		"description": "combinatorial process block"
+		"description": "process all block"
 	},
 	"Record": {
 		"prefix": "typerecord",
@@ -538,8 +610,8 @@
 		"description": "record declaration"
 	},
 	"Signed": {
-		"prefix": "sign",
-		"body": [ "signed($1 ${2|downto,to|} $3)${4| := (others => '0');,;|}$0" ],
+		"prefix": "signed",
+		"body": [ "signed($1 ${2|downto,to|} $3)${4| := (others=>'0');,;|}$0" ],
 		"description": "signed declaration"
 	},
 	"Standard Logic": {
@@ -578,7 +650,7 @@
 			"subtype ${1:<name>} is ${2:<base_type>} range ${3:0} ${4|to,downto|} ${5:<value>};",
 			"$0"
 		],
-		"description": "std_ulogic_vector declaration"
+		"description": "subtype declaration"
 	},
 	"Unsigned": {
 		"prefix": "uns",
@@ -612,7 +684,7 @@
 	"When Else": {
 		"prefix": "whenelse",
 		"body": [
-			"${1:<signal>} <= ${2:<value>} when ${3:<conditional>} else ${4:<value>};",
+			"${1:WHEN_ELSE_NAME} : ${2:<signal>} <= ${3:<value>} when ${4:<conditional>} else ${5:<value>};",
 			"$0"
 		],
 		"description": "concurrent when else declaration"

--- a/src/teroshdl/features/tree_views/dependency/element.ts
+++ b/src/teroshdl/features/tree_views/dependency/element.ts
@@ -111,6 +111,7 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
             const element = this.hdl_tree[i];
             if (element.filename === toplevel_path) {
                 current_dep = element;
+                break;
             }
         }
         // const current_dep = await this.get_deps(toplevel_path);
@@ -118,25 +119,34 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
             return [];
         }
 
+
+
+
+
         // Dependencie view
         const dependency_view = this.get_dep_view(current_dep);
 
         if (element) {
+            
             dependency_view.forEach(item => {
-                if (typeof item.label === "string") {
-                    if (item.label.endsWith(".vhd")) {
-                        item.label = item.label.slice(0, -4)
-                            + " : (" + toItalic(item.label) + ")"; // ejemplo: reescribir
-                    } else if (item.label.endsWith(".v")) {
-                        item.label = item.label.slice(0, -2)
-                            + " : (" + toItalic(item.label) + ")"; // ejemplo: reescribir
-                    }
+
+                const filename = item.label?.toString() || '';
+
+                if (filename.endsWith(".vhd")) {
+                    item.iconPath = get_icon("vhdl");
+                    item.label = filename.slice(0, -4);
                 }
+                else if (filename.endsWith(".v")) {
+                    item.label = filename.slice(0, -2);
+                    item.iconPath = get_icon("verilog");
+                }
+
+                item.description = filename;
             });
             return dependency_view;
         }
         else {
-            return [new Dependency((<any>current_dep).filename, (<any>current_dep).entity, dependency_view)];
+            return [new Dependency((current_dep).filename, (current_dep).entity, dependency_view)];
         }
     }
 
@@ -176,7 +186,6 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
     }
 
     private async get_deps(top_path: string) {
-        let current_dep = undefined;
         const hdl_tree = await this.get_hdl_tree();
 
         if (hdl_tree === undefined) {
@@ -186,10 +195,9 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         for (let i = 0; i < this.hdl_tree.length; i++) {
             const element = this.hdl_tree[i];
             if (element.filename === top_path) {
-                current_dep = element;
+                return element;
             }
         }
-        return current_dep;
     }
 
     get_dep_view(deps) {
@@ -244,21 +252,4 @@ export class TreeItem extends vscode.TreeItem {
                 vscode.TreeItemCollapsibleState.Expanded);
         this.children = children;
     }
-}
-
-function toItalic(text: string): string {
-    const map: Record<string, string> = {
-        a: "𝘢", b: "𝘣", c: "𝘤", d: "𝘥",
-        e: "𝘦", f: "𝘧", g: "𝘨", h: "𝘩",
-        i: "𝘪", j: "𝘫", k: "𝘬", l: "𝘭",
-        m: "𝘮", n: "𝘯", o: "𝘰", p: "𝘱",
-        q: "𝘲", r: "𝘳", s: "𝘴", t: "𝘵",
-        u: "𝘶", v: "𝘷", w: "𝘸", x: "𝘹",
-        y: "𝘺", z: "𝘻"
-    };
-
-    return text
-        .split("")
-        .map(c => map[c.toLowerCase()] ?? c)
-        .join("");
 }

--- a/src/teroshdl/features/tree_views/dependency/element.ts
+++ b/src/teroshdl/features/tree_views/dependency/element.ts
@@ -122,6 +122,17 @@ export class ProjectProvider extends BaseTreeDataProvider<TreeItem> {
         const dependency_view = this.get_dep_view(current_dep);
 
         if (element) {
+            dependency_view.forEach(item => {
+                if (typeof item.label === "string") {
+                    if (item.label.endsWith(".vhd")) {
+                        item.label = item.label.slice(0, -4)
+                            + " : (" + toItalic(item.label) + ")"; // ejemplo: reescribir
+                    } else if (item.label.endsWith(".v")) {
+                        item.label = item.label.slice(0, -2)
+                            + " : (" + toItalic(item.label) + ")"; // ejemplo: reescribir
+                    }
+                }
+            });
             return dependency_view;
         }
         else {
@@ -235,3 +246,19 @@ export class TreeItem extends vscode.TreeItem {
     }
 }
 
+function toItalic(text: string): string {
+    const map: Record<string, string> = {
+        a: "𝘢", b: "𝘣", c: "𝘤", d: "𝘥",
+        e: "𝘦", f: "𝘧", g: "𝘨", h: "𝘩",
+        i: "𝘪", j: "𝘫", k: "𝘬", l: "𝘭",
+        m: "𝘮", n: "𝘯", o: "𝘰", p: "𝘱",
+        q: "𝘲", r: "𝘳", s: "𝘴", t: "𝘵",
+        u: "𝘶", v: "𝘷", w: "𝘸", x: "𝘹",
+        y: "𝘺", z: "𝘻"
+    };
+
+    return text
+        .split("")
+        .map(c => map[c.toLowerCase()] ?? c)
+        .join("");
+}


### PR DESCRIPTION
This improve hierarchy showing the name of the entity* and the name of the file as a label.
This also selects the icon depending of which file is going to be showed.

Note: the first file it is very difficult for me now touch it, because it follows other flow than the rest of the files.

_*This is not the real entity name, is the name of the file without the extension (in a future the idea is to show the entity name)_

In VHDL
<img width="490" height="351" alt="Captura desde 2026-05-15 08-27-24" src="https://github.com/user-attachments/assets/c0de3236-f1d5-4492-8bb4-1dd063427840" />

In verilog
<img width="508" height="468" alt="Captura desde 2026-05-15 08-31-01" src="https://github.com/user-attachments/assets/1c325b67-6dd6-45d6-bb9b-ccd1fb46e673" />
