### PR TITLE
This insert sthe name of the entity in the title of the exported html

### DIFF
--- a/src/colibri/documenter/css.ts
+++ b/src/colibri/documenter/css.ts
@@ -1102,7 +1102,11 @@ export const html_style_preview = `
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
-    <title>TerosHDL</title>
+    <title>`;
+
+
+
+export const html_style_preview_second_part = `</title>
   <style>
     body {
       box-sizing: border-box;
@@ -2197,7 +2201,11 @@ export const html_style_save = `
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
-    <title>TerosHDL</title>
+    <title>`;
+    
+    
+    
+export const html_style_save_second_part = `</title>
   <style>
     body {
       box-sizing: border-box;

--- a/src/colibri/documenter/documenter.ts
+++ b/src/colibri/documenter/documenter.ts
@@ -85,29 +85,30 @@ export class Documenter extends section_creator.Creator {
     async get_document(code: string, lang: LANGUAGE, configuration: t_documenter_options,
         save: boolean, input_path: string, output_svg_dir: string, extra_top_space: boolean,
         output_type: common_documenter.doc_output_type): Promise<result_type> {
-            
+
         let code_fix = "";
         // const svg_dir_path = path_lib.dirname(output_svg_dir);
         // const filename_svg = path_lib.basename(input_path, path_lib.extname(input_path));
 
         // Fix multiline code in HTML:
         if (output_type === common_documenter.doc_output_type.HTML) {
-            if(lang === LANGUAGE.VHDL){
+            if (lang === LANGUAGE.VHDL) {
                 const vhdl_symbol = configuration.vhdl_symbol;
-                code_fix = code.replace(/```[^]*```/g, function(match){
-                    return match.replace(/\n/g, '\n--' + vhdl_symbol +' \n');});
-            }            
-            else if(lang === LANGUAGE.VERILOG || lang === LANGUAGE.SYSTEMVERILOG){
-                const verilog_symbol = configuration.verilog_symbol;
-                code_fix = code.replace(/```[^]*```/g, function(match){
-                    return match.replace(/\n/g, '\n//' + verilog_symbol +' \n');});
+                code_fix = code.replace(/```[^]*```/g, function (match) {
+                    return match.replace(/\n/g, '\n--' + vhdl_symbol + ' \n');
+                });
             }
-            else
-            {
+            else if (lang === LANGUAGE.VERILOG || lang === LANGUAGE.SYSTEMVERILOG) {
+                const verilog_symbol = configuration.verilog_symbol;
+                code_fix = code.replace(/```[^]*```/g, function (match) {
+                    return match.replace(/\n/g, '\n//' + verilog_symbol + ' \n');
+                });
+            }
+            else {
                 code_fix = code;
             }
 
-        }else{
+        } else {
             code_fix = code;
         }
 
@@ -120,19 +121,32 @@ export class Documenter extends section_creator.Creator {
             return result;
         }
 
+        // Get the entity name
+        const name_entity = hdl_element.name;
+
         ////////////////////////////////////////////////////////////////////////
         // HTML preparation
         ////////////////////////////////////////////////////////////////////////
         let html_style = '';
         if (save) {
             html_style = `<div id="teroshdl" class='templateTerosHDL'>\n`;
-            html_style = css_const_style.html_style_save + html_style;
+            // Inser the entity name inside the title tag
+            html_style =
+                css_const_style.html_style_save +
+                name_entity +   // entity name
+                css_const_style.html_style_save_second_part +
+                html_style;
         }
         else {
             // eslint-disable-next-line max-len
             html_style = `<div id="teroshdl" class='templateTerosHDL' style="overflow-y:auto;height:100%;width:100%">\n`;
             html_style = '';
-            html_style = css_const_style.html_style_preview + html_style;
+            // Inser the entity name inside the title tag
+            html_style =
+                css_const_style.html_style_preview +
+                name_entity +   // entity name
+                css_const_style.html_style_preview_second_part +
+                html_style;
         }
         let html = html_style;
         if (extra_top_space) {


### PR DESCRIPTION
This pull request changes the name of the exported HTMl from TerosHDL to the name of the entity.

To do that it is splitted the html template, one from the previous part of the <title> and other after </title>.

<img width="504" height="61" alt="Captura desde 2026-05-16 19-52-03" src="https://github.com/user-attachments/assets/c6db13d6-8906-4c5c-8eca-b7db261e5564" />
