### PR TITLE
Fixed vsg linter not using full path

### DIFF
--- a/src/colibri/linter/vsg.ts
+++ b/src/colibri/linter/vsg.ts
@@ -82,10 +82,12 @@ export class Vsg extends Base_linter {
         const code_file_normalized = file_path.replace(' ', '\\ ');
         const json_file_file_normalized = junit_file.replace(' ', '\\ ');
 
-        let command = `vsg -f ${code_file_normalized} --all_phases --js ${json_file_file_normalized}`;
+        const binary_path = options.path ? `${options.path}/${this.binary}` : this.binary;
+
+        let command = `${binary_path} -f ${code_file_normalized} --all_phases --js ${json_file_file_normalized}`;
         if (options.argument !== ""){
             // eslint-disable-next-line max-len
-            command = `vsg -f ${code_file_normalized} --all_phases -c ${options.argument} --js ${json_file_file_normalized}`;
+            command = `${binary_path} -f ${code_file_normalized} --all_phases -c ${options.argument} --js ${json_file_file_normalized}`;
         }
 
         const msg = `Linting with command: ${command} `;


### PR DESCRIPTION
Currently, VSG linter is not looking at the VSG installation path, but just uses directly the binary assuming is on the path. If you have installed VSG on a virtual environment, then it doesn't find it. This fix makes it look at the installation path.
